### PR TITLE
[infra #8] Zipkin 기반 분산 트레이싱 구현

### DIFF
--- a/apigateway-service/build.gradle
+++ b/apigateway-service/build.gradle
@@ -49,6 +49,13 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //zipkin
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave:2.16.3'
+    implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.16.3' // optional, HTTP 전송 시
+    implementation 'io.zipkin.brave:brave-instrumentation-grpc:5.13.3' // gRPC 추적 시
+
     // data jpa, h2, postgresql
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/apigateway-service/src/main/java/hanium/apigateway_service/config/GrpcTracingClientInterceptorConfig.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/config/GrpcTracingClientInterceptorConfig.java
@@ -1,0 +1,16 @@
+package hanium.apigateway_service.config;
+
+import brave.Tracing;
+import brave.grpc.GrpcTracing;
+import io.grpc.ClientInterceptor;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcTracingClientInterceptorConfig {
+    // Brave의 Tracing 객체를 주입받아 GrpcTracing을 생성
+    @GrpcGlobalClientInterceptor
+    public ClientInterceptor tracingClientInterceptor(Tracing tracing) {
+        return GrpcTracing.create(tracing).newClientInterceptor();
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/config/GrpcTracingServerInterceptorConfig.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/config/GrpcTracingServerInterceptorConfig.java
@@ -1,0 +1,16 @@
+package hanium.apigateway_service.config;
+
+import brave.Tracing;
+import brave.grpc.GrpcTracing;
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcTracingServerInterceptorConfig {
+
+    @GrpcGlobalServerInterceptor
+    public ServerInterceptor tracingServerInterceptor(Tracing tracing) {
+        return GrpcTracing.create(tracing).newServerInterceptor();
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/config/ZipkinSenderConfig.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/config/ZipkinSenderConfig.java
@@ -1,0 +1,15 @@
+package hanium.apigateway_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.reporter.Sender;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+@Configuration
+public class ZipkinSenderConfig {
+
+    @Bean
+    public Sender zipkinSender() {
+        return OkHttpSender.create("http://zipkin:9411/api/v2/spans");
+    }
+}

--- a/community-service/build.gradle
+++ b/community-service/build.gradle
@@ -54,6 +54,15 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	//zipkin
+	implementation 'io.zipkin.brave:brave-instrumentation-grpc:5.13.3'
+	implementation 'io.micrometer:micrometer-tracing:1.1.6'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave:1.1.6'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave:2.16.3'
+	implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.16.3'
+	implementation 'io.zipkin.zipkin2:zipkin:2.23.16'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// data jpa, h2, postgresql
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/community-service/src/main/java/hanium/community_service/Service/impl/PostServiceImpl.java
+++ b/community-service/src/main/java/hanium/community_service/Service/impl/PostServiceImpl.java
@@ -7,6 +7,7 @@ import hanium.community_service.dto.CreatePostRequestDTO;
 import hanium.community_service.entity.Post;
 import hanium.community_service.mapper.entity.PostEntityMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import hanium.community_service.Repository.PostRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
  * PostServiceImpl은 PostService 인터페이스의 구현체로,
  * 게시글 생성과 관련된 비즈니스 로직을 담당합니다.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PostServiceImpl implements PostService {
@@ -29,6 +31,7 @@ public class PostServiceImpl implements PostService {
         }
         Post post = PostEntityMapper.toEntity(dto);
 
+        log.info("✅ 글 작성 성공: {}", post.getTitle());
         postRepository.save(post);
     }
 }

--- a/community-service/src/main/java/hanium/community_service/config/GrpcTracingServerInterceptorConfig.java
+++ b/community-service/src/main/java/hanium/community_service/config/GrpcTracingServerInterceptorConfig.java
@@ -1,0 +1,16 @@
+package hanium.community_service.config;
+
+import brave.Tracing;
+import brave.grpc.GrpcTracing;
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcTracingServerInterceptorConfig {
+
+    @GrpcGlobalServerInterceptor
+    public ServerInterceptor tracingServerInterceptor(Tracing tracing) {
+        return GrpcTracing.create(tracing).newServerInterceptor();
+    }
+}

--- a/community-service/src/main/java/hanium/community_service/config/ZipkinSenderConfig.java
+++ b/community-service/src/main/java/hanium/community_service/config/ZipkinSenderConfig.java
@@ -1,0 +1,19 @@
+package hanium.community_service.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.reporter.Sender;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+@Configuration
+public class ZipkinSenderConfig {
+
+    @Value("${ZIPKIN_ENDPOINT:http://zipkin:9411/api/v2/spans}")
+    private String zipkinEndpoint;
+
+    @Bean
+    public Sender zipkinSender() {
+        return OkHttpSender.create(zipkinEndpoint);
+    }
+}

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -54,6 +54,15 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	//zipkin
+	implementation 'io.zipkin.brave:brave-instrumentation-grpc:5.13.3'
+	implementation 'io.micrometer:micrometer-tracing:1.1.6'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave:1.1.6'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave:2.16.3'
+	implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.16.3'
+	implementation 'io.zipkin.zipkin2:zipkin:2.23.16'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// data jpa, h2, postgresql
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/notification-service/src/main/java/hanium/notification_service/config/GrpcTracingServerInterceptorConfig.java
+++ b/notification-service/src/main/java/hanium/notification_service/config/GrpcTracingServerInterceptorConfig.java
@@ -1,0 +1,16 @@
+package hanium.notification_service.config;
+
+import brave.Tracing;
+import brave.grpc.GrpcTracing;
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcTracingServerInterceptorConfig {
+
+    @GrpcGlobalServerInterceptor
+    public ServerInterceptor tracingServerInterceptor(Tracing tracing) {
+        return GrpcTracing.create(tracing).newServerInterceptor();
+    }
+}

--- a/notification-service/src/main/java/hanium/notification_service/config/ZipkinSenderConfig.java
+++ b/notification-service/src/main/java/hanium/notification_service/config/ZipkinSenderConfig.java
@@ -1,0 +1,19 @@
+package hanium.notification_service.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.reporter.Sender;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+@Configuration
+public class ZipkinSenderConfig {
+
+    @Value("${ZIPKIN_ENDPOINT:http://zipkin:9411/api/v2/spans}")
+    private String zipkinEndpoint;
+
+    @Bean
+    public Sender zipkinSender() {
+        return OkHttpSender.create(zipkinEndpoint);
+    }
+}

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -53,6 +53,15 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	//zipkin
+	implementation 'io.zipkin.brave:brave-instrumentation-grpc:5.13.3'
+	implementation 'io.micrometer:micrometer-tracing:1.1.6'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave:1.1.6'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave:2.16.3'
+	implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.16.3'
+	implementation 'io.zipkin.zipkin2:zipkin:2.23.16'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// data jpa, h2, postgresql
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/product-service/src/main/java/hanium/product_service/config/GrpcTracingServerInterceptorConfig.java
+++ b/product-service/src/main/java/hanium/product_service/config/GrpcTracingServerInterceptorConfig.java
@@ -1,0 +1,16 @@
+package hanium.product_service.config;
+
+import brave.Tracing;
+import brave.grpc.GrpcTracing;
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcTracingServerInterceptorConfig {
+
+    @GrpcGlobalServerInterceptor
+    public ServerInterceptor tracingServerInterceptor(Tracing tracing) {
+        return GrpcTracing.create(tracing).newServerInterceptor();
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/config/ZipkinSenderConfig.java
+++ b/product-service/src/main/java/hanium/product_service/config/ZipkinSenderConfig.java
@@ -1,0 +1,19 @@
+package hanium.product_service.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.reporter.Sender;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+@Configuration
+public class ZipkinSenderConfig {
+
+    @Value("${ZIPKIN_ENDPOINT:http://zipkin:9411/api/v2/spans}")
+    private String zipkinEndpoint;
+
+    @Bean
+    public Sender zipkinSender() {
+        return OkHttpSender.create(zipkinEndpoint);
+    }
+}

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -55,6 +55,16 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //zipkin
+    implementation 'io.zipkin.brave:brave-instrumentation-grpc:5.13.3'
+    implementation 'io.micrometer:micrometer-tracing:1.1.6'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave:1.1.6'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave:2.16.3'
+    implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.16.3'
+    implementation 'io.zipkin.zipkin2:zipkin:2.23.16'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+
     // data jpa, h2, postgresql
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/user-service/src/main/java/hanium/user_service/config/GrpcTracingServerInterceptorConfig.java
+++ b/user-service/src/main/java/hanium/user_service/config/GrpcTracingServerInterceptorConfig.java
@@ -1,0 +1,16 @@
+package hanium.user_service.config;
+
+import brave.Tracing;
+import brave.grpc.GrpcTracing;
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcTracingServerInterceptorConfig {
+
+    @GrpcGlobalServerInterceptor
+    public ServerInterceptor tracingServerInterceptor(Tracing tracing) {
+        return GrpcTracing.create(tracing).newServerInterceptor();
+    }
+}

--- a/user-service/src/main/java/hanium/user_service/config/ZipkinSenderConfig.java
+++ b/user-service/src/main/java/hanium/user_service/config/ZipkinSenderConfig.java
@@ -1,0 +1,19 @@
+package hanium.user_service.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.reporter.Sender;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+@Configuration
+public class ZipkinSenderConfig {
+
+    @Value("${ZIPKIN_ENDPOINT:http://zipkin:9411/api/v2/spans}")
+    private String zipkinEndpoint;
+
+    @Bean
+    public Sender zipkinSender() {
+        return OkHttpSender.create(zipkinEndpoint);
+    }
+}

--- a/user-service/src/main/java/hanium/user_service/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/AuthServiceImpl.java
@@ -78,6 +78,7 @@ public class AuthServiceImpl implements AuthService {
         if (!refreshToken.isEmpty()) {
             refreshRepository.deleteAll(refreshToken);
         }
+        log.info("✅ 로그인 성공: {}", member.getId());
         return jwtUtil.respondTokens(member);
     }
 }


### PR DESCRIPTION
# 💻 PR 설명
마이크로서비스 간 요청 흐름을 추적할 수 있도록 Zipkin 기반의 분산 트레이싱 기능을 구현 (issue #8)
API Gateway → gRPC → 각 서비스로 이어지는 호출이 단일 Trace ID로 연결되어, Zipkin UI에서 요청 전체 흐름을 시각적으로 확인 가능
# ✅ 작업 내용
- docker-compose.yml에 Zipkin 서비스 추가 (http://localhost:9411)
- 각 서비스에 Zipkin + Brave + Micrometer 의존성 추가 (build.gradle)
- application.yml에 management.tracing.zipkin.endpoint 설정
→ config repo에 반영 완료
- 공통 모듈이 아닌, 각 서비스별로 Tracing / Sender / Interceptor 설정 분리
- API Gateway ↔ 각 서비스 간 gRPC 호출 흐름의 trace 전파 정상 확인
# 👀 결과
<img width="1307" height="548" alt="스크린샷 2025-07-19 오전 8 48 55" src="https://github.com/user-attachments/assets/f133ae01-bdd9-426d-9fa2-dbc34886d979" />

- 회원가입 요청(/user/auth/signup)이 API Gateway를 거쳐 user-service까지 전달되는 전체 트랜잭션 흐름을 시각화한 결과
👉 http://localhost:9411
- 모든 작업은 단일 Trace ID (687adb63155fe72813b474d9cb794fa4)로 묶여 있고, Zipkin은 이 트랜잭션을 여러 스팬(Span) 단위로 나눠서 보여줌

### 용어정리
용어 | 설명
-- | --
Trace | 하나의 요청 전체 흐름 (예: 회원가입)
Span | 요청 안의 개별 작업 단위 (예: gRPC 호출, 필터 통과 등)
Trace ID | 전체 요청을 식별하는 고유 ID
Parent/Child Span | 상위 요청-하위 작업 관계 (ex. HTTP → gRPC)
Duration | 각 작업이 소요된 시간 (밀리초)

# 📌 참고
### 해석 방법
**요청 흐름**: API Gateway (/user/auth/signup) → gRPC 호출 → user-service의 signUp 메서드
**Trace ID**: Zipkin UI 상단에서 하나의 Trace로 묶여 있는 것을 확인할 수 있음
**Span**: 하나의 요청 안에서 여러 작업(필터, 인증, gRPC 호출 등)이 단계별로 시각화되어 있으며, 각 작업의 수행 시간(ms)도 확인 가능
**성공 기준**: APIGATEWAY-SERVICE와 USER-SERVICE가 동일한 Trace ID 안에 있고 gRPC 메서드 호출 (e.g. userservice/signup)이 자식 Span으로 연결되어 있으면 Trace 전파 성공

### 이 결과로 알 수 있는 것
trace가 끊기지 않고 Gateway ↔ user-service까지 단일 흐름으로 이어짐 → ✔️ trace 전파 성공
어느 서비스가 느렸는지 한눈에 파악 가능 → ex. user-service의 signup 처리에 약 680ms 소요됨
Spring Security 인증, gRPC 호출, 내부 로직 시간까지 정밀 추적 가능

# 📝 추후 작업 예정
- user-service 및 community-service 등에도 gRPC Client Interceptor 추가 예정  
  → 서비스 간 호출에서도 trace context가 유지되도록 개선할 예정