### PR TITLE
[test #34] 소셜 로그인으로 신규 회원가입 테스트

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/config/SecurityConfig.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package hanium.apigateway_service.security;
+package hanium.apigateway_service.config;
 
 import hanium.apigateway_service.security.filter.ExceptionHandlerFilter;
 import hanium.apigateway_service.security.filter.JwtAuthenticationFilter;
@@ -30,7 +30,7 @@ public class SecurityConfig {
                                 "/user/auth/**",
                                 "/user/sms/**",
                                 "/health/**",       // 나머지 서비스 헬스 체크
-                                "/health-check",     // apigateway 헬스체크
+                                "/health-check",    // apigateway 헬스체크
                                 "/actuator/**"
                         ).permitAll() // 인증 없이 허용
                         .anyRequest().authenticated())

--- a/user-service/src/main/java/hanium/user_service/dto/response/KakaoUserResponseDTO.java
+++ b/user-service/src/main/java/hanium/user_service/dto/response/KakaoUserResponseDTO.java
@@ -19,62 +19,23 @@ public class KakaoUserResponseDTO {
     public KakaoAccount kakaoAccount;
 
     @Getter
+    @Builder
+    @AllArgsConstructor
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoAccount {
-
-        //프로필 정보 제공 동의 여부
-        @JsonProperty("profile_needs_agreement")
-        public Boolean isProfileAgree;
-
-        //닉네임 제공 동의 여부
-        @JsonProperty("profile_nickname_needs_agreement")
-        public Boolean isNickNameAgree;
-
-        //프로필 사진 제공 동의 여부
-        @JsonProperty("profile_image_needs_agreement")
-        public Boolean isProfileImageAgree;
 
         //사용자 프로필 정보
         @JsonProperty("profile")
         public Profile profile;
 
-        //이름 제공 동의 여부
-        @JsonProperty("name_needs_agreement")
-        public Boolean isNameAgree;
-
-        //카카오계정 이름
-        @JsonProperty("name")
-        public String name;
-
-        //이메일 제공 동의 여부
-        @JsonProperty("email_needs_agreement")
-        public Boolean isEmailAgree;
-
-        //이메일이 유효 여부
-        // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
-        @JsonProperty("is_email_valid")
-        public Boolean isEmailValid;
-
-        //이메일이 인증 여부
-        //true : 인증된 이메일, false : 인증되지 않은 이메일
-        @JsonProperty("is_email_verified")
-        public Boolean isEmailVerified;
-
         //카카오계정 대표 이메일
         @JsonProperty("email")
         public String email;
 
-        //전화번호 제공 동의 여부
-        @JsonProperty("phone_number_needs_agreement")
-        public Boolean isPhoneNumberAgree;
-
-        //전화번호
-        //국내 번호인 경우 +82 00-0000-0000 형식
-        @JsonProperty("phone_number")
-        public String phoneNumber;
-
         @Getter
+        @Builder
+        @AllArgsConstructor
         @NoArgsConstructor
         @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Profile {

--- a/user-service/src/main/java/hanium/user_service/dto/response/NaverUserResponseDTO.java
+++ b/user-service/src/main/java/hanium/user_service/dto/response/NaverUserResponseDTO.java
@@ -23,6 +23,8 @@ public class NaverUserResponseDTO {
     public Response naverAccount;
 
     @Getter
+    @Builder
+    @AllArgsConstructor
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Response {

--- a/user-service/src/main/java/hanium/user_service/service/OAuthService.java
+++ b/user-service/src/main/java/hanium/user_service/service/OAuthService.java
@@ -1,6 +1,8 @@
 package hanium.user_service.service;
 
+import hanium.user_service.dto.response.KakaoUserResponseDTO;
 import hanium.user_service.dto.response.NaverConfigResponseDTO;
+import hanium.user_service.dto.response.NaverUserResponseDTO;
 import hanium.user_service.dto.response.TokenResponseDTO;
 
 import java.util.Map;
@@ -13,5 +15,10 @@ public interface OAuthService {
 
     TokenResponseDTO kakaoLogin(String code);
 
+    TokenResponseDTO kakaoSignupAndLogin(KakaoUserResponseDTO.KakaoAccount kakaoUser,
+                                         KakaoUserResponseDTO.KakaoAccount.Profile kakaoProfile);
+
     TokenResponseDTO naverLogin(String code);
+
+    TokenResponseDTO naverSignupAndLogin(NaverUserResponseDTO.Response naverUser);
 }

--- a/user-service/src/main/java/hanium/user_service/service/impl/OAuthServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/OAuthServiceImpl.java
@@ -212,8 +212,8 @@ public class OAuthServiceImpl implements OAuthService {
      * @param kakaoProfile 카카오 프로필 정보
      * @return 로그인 결과 토큰
      */
-    private TokenResponseDTO kakaoSignupAndLogin(KakaoUserResponseDTO.KakaoAccount kakaoUser,
-                                                 KakaoUserResponseDTO.KakaoAccount.Profile kakaoProfile) {
+    public TokenResponseDTO kakaoSignupAndLogin(KakaoUserResponseDTO.KakaoAccount kakaoUser,
+                                                KakaoUserResponseDTO.KakaoAccount.Profile kakaoProfile) {
         Member member = Member.builder()
                 .email(kakaoUser.getEmail()).provider(Provider.KAKAO).role(Role.USER)
                 .isAgreeMarketing(false).isAgreeThirdParty(false)
@@ -233,7 +233,7 @@ public class OAuthServiceImpl implements OAuthService {
      * @param naverUser 네이버 계정 정보
      * @return 로그인 결과 토큰
      */
-    private TokenResponseDTO naverSignupAndLogin(NaverUserResponseDTO.Response naverUser) {
+    public TokenResponseDTO naverSignupAndLogin(NaverUserResponseDTO.Response naverUser) {
         Member member = Member.builder()
                 .email(naverUser.getEmail())
                 .phoneNumber(naverUser.getMobile().replaceAll("\\D+", ""))

--- a/user-service/src/test/java/hanium/user_service/service/OAuthServiceImplTest.java
+++ b/user-service/src/test/java/hanium/user_service/service/OAuthServiceImplTest.java
@@ -1,0 +1,76 @@
+package hanium.user_service.service;
+
+import hanium.user_service.domain.Member;
+import hanium.user_service.dto.response.KakaoUserResponseDTO;
+import hanium.user_service.dto.response.NaverUserResponseDTO;
+import hanium.user_service.dto.response.TokenResponseDTO;
+import hanium.user_service.repository.MemberRepository;
+import hanium.user_service.repository.RefreshTokenRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class OAuthServiceImplTest {
+
+    private final OAuthService oAuthService;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private KakaoUserResponseDTO.KakaoAccount kakaoAccount;
+    private NaverUserResponseDTO.Response naverAccount;
+
+    @Autowired
+    public OAuthServiceImplTest(OAuthService oAuthService, MemberRepository memberRepository,
+                                RefreshTokenRepository refreshTokenRepository) {
+        this.oAuthService = oAuthService;
+        this.memberRepository = memberRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @BeforeEach
+    void setUp() {
+        KakaoUserResponseDTO.KakaoAccount.Profile profile = KakaoUserResponseDTO.KakaoAccount.Profile.builder()
+                .nickName("카카오닉네임").profileImageUrl("/path/kakao_profile_image").build();
+        kakaoAccount = KakaoUserResponseDTO.KakaoAccount.builder()
+                .email("email@kakao.com").profile(profile).build();
+        naverAccount = NaverUserResponseDTO.Response.builder()
+                .email("email@naver.com").nickname("네이버닉네임").mobile("010-6789-2345")
+                .profileImage("/path/naver_profile_image").build();
+    }
+
+    @Test
+    @DisplayName("카카오 계정으로 신규 회원가입")
+    void kakaoSignupAndLogin() {
+        // when
+        TokenResponseDTO dto = oAuthService.kakaoSignupAndLogin(kakaoAccount, kakaoAccount.getProfile());
+        Member member = memberRepository.findByEmail(kakaoAccount.getEmail()).get();
+        // then
+        assertThat(refreshTokenRepository.findByMember(member).getFirst().getToken())
+                .isEqualTo(dto.getRefreshToken());
+        assertThat(member.getProvider().toString())
+                .isEqualTo("KAKAO");
+    }
+
+    @Test
+    @DisplayName("네이버 계정으로 신규 회원가입")
+    void naverSignupAndLogin() {
+        // when
+        TokenResponseDTO dto = oAuthService.naverSignupAndLogin(naverAccount);
+        Member member = memberRepository.findByEmail(naverAccount.getEmail()).get();
+        // then
+        assertThat(refreshTokenRepository.findByMember(member).getFirst().getToken())
+                .isEqualTo(dto.getRefreshToken());
+        assertThat(member.getProvider().toString())
+                .isEqualTo("NAVER");
+        assertThat(member.getPhoneNumber()).isEqualTo("01067892345");
+    }
+}


### PR DESCRIPTION
## 테스트 내용
소셜 로그인 과정으로 서비스에 신규 회원가입하게 되는 로직을 테스트합니다. Closes #34 
노션 설정파일 user-service application-test.yml을 확인해 로컬 업데이트가 필요합니다.

- 가져온 카카오 계정 정보로 서비스 회원가입 및 즉시 로그인 테스트
  - RefreshToken 생성 확인
  - 생성된 사용자의 provider가 KAKAO인지 확인
- 가져온 네이버 계정 정보로 서비스 회원가입 및 즉시 로그인으로 RefreshToken 생성 확인
  - 전화번호 형식이 네이버 상 (010-1234-1234)에서 (01012341234)로 변환 확인
  - RefreshToken 생성 확인
  - 생성된 사용자의 provider가 KAKAO인지 확인

_외부 소셜로그인 API로 인가 코드 받거나, 계정 정보 가져오는 과정은 테스트 생략하고 내부 로직 테스트만 수행했습니다._

<img width="379" height="329" alt="image" src="https://github.com/user-attachments/assets/18544dfd-a2ac-4533-841c-e7d4f36a93b4" />
