### PR TITLE
[chore #48] 소셜로그인 로그 추가

### DIFF
--- a/user-service/src/main/java/hanium/user_service/service/impl/OAuthServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/OAuthServiceImpl.java
@@ -197,7 +197,7 @@ public class OAuthServiceImpl implements OAuthService {
      * @return 로그인 결과 토큰
      */
     private TokenResponseDTO proceedSocialLogin(Member member) {
-        log.info("✅ Social Account [{}] exists: {}", member.getProvider(), member.getEmail());
+        log.info("✅ [Social acc] Login Success: provider={}, id={}", member.getProvider(), member.getId());
         List<RefreshToken> refreshToken = refreshRepository.findByMember(member);
         if (!refreshToken.isEmpty()) {
             refreshRepository.deleteAll(refreshToken);
@@ -224,6 +224,7 @@ public class OAuthServiceImpl implements OAuthService {
                 .member(member).build();
         memberRepository.save(member);
         profileRepository.save(profile);
+        log.info("✅ [New Kakao Account Signup] Login Success: id={}", member.getId());
         return jwtUtil.respondTokens(member);
     }
 
@@ -246,6 +247,7 @@ public class OAuthServiceImpl implements OAuthService {
                 .member(member).build();
         memberRepository.save(member);
         profileRepository.save(profile);
+        log.info("✅ [New Naver Account Signup] Login Success: id={}", member.getId());
         return jwtUtil.respondTokens(member);
     }
 


### PR DESCRIPTION
## 💡 관련 이슈
<!-- 관련된 이슈를 연결해주세요 -->
Closes #48

## 💼 작업 설명
<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->
소셜로그인 구분을 위한 로그를 추가했습니다.

## ✅ 구현/변경사항
<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
hanium/user_service/service/impl/OAuthServiceImpl.java
- 소셜 회원가입 기록이 있는 로그인의 경우: `✅ [Social acc] Login Success: provider={}, id={}`
- 신규 카카오 회원가입+로그인의 경우: `✅ [New Kakao Account Signup] Login Success: id={}`
- 신규 네이버 회원가입+로그인의 경우: `✅ [New Naver Account Signup] Login Success: id={}`