### PR TITLE
[feat #53] 상품 관심(찜) 기능 구현 

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/ProductController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/ProductController.java
@@ -6,6 +6,7 @@ import hanium.apigateway_service.dto.product.request.RegisterProductRequestDTO;
 import hanium.apigateway_service.dto.product.request.UpdateProductRequestDTO;
 import hanium.apigateway_service.dto.product.response.ProductMainDTO;
 import hanium.apigateway_service.dto.product.response.ProductResponseDTO;
+import hanium.apigateway_service.dto.product.response.SimpleProductDTO;
 import hanium.apigateway_service.grpc.ProductGrpcClient;
 import hanium.apigateway_service.response.ResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -95,6 +96,28 @@ public class ProductController {
         productGrpcClient.deleteProduct(productId, memberId);
         ResponseDTO<ProductResponseDTO> response = new ResponseDTO<>(
                 null, HttpStatus.OK, "상품이 삭제되었습니다.");
+        return ResponseEntity.ok(response);
+    }
+
+    // 상품 찜/찜 취소
+    @PostMapping("/like/{productId}")
+    public ResponseEntity<?> likeProduct(@PathVariable Long productId, Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        String message = productGrpcClient.likeProduct(memberId, productId);
+        ResponseDTO<?> response = new ResponseDTO<>(null, HttpStatus.OK, message);
+        return ResponseEntity.ok(response);
+    }
+
+    // 상품 찜 목록 조회
+    @GetMapping("/like")
+    public ResponseEntity<ResponseDTO<List<SimpleProductDTO>>> getLikedProducts(
+            Authentication authentication,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        List<SimpleProductDTO> result = productGrpcClient.getLikedProducts(memberId, page);
+        ResponseDTO<List<SimpleProductDTO>> response = new ResponseDTO<>(
+                result, HttpStatus.OK, "상품 찜 목록이 20개씩 조회되었습니다.");
         return ResponseEntity.ok(response);
     }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/ProductController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/ProductController.java
@@ -110,12 +110,12 @@ public class ProductController {
 
     // 상품 찜 목록 조회
     @GetMapping("/like")
-    public ResponseEntity<ResponseDTO<List<SimpleProductDTO>>> getLikedProducts(
+    public ResponseEntity<ResponseDTO<List<SimpleProductDTO>>> getLikeProducts(
             Authentication authentication,
             @RequestParam(defaultValue = "0") int page
     ) {
         Long memberId = (Long) authentication.getPrincipal();
-        List<SimpleProductDTO> result = productGrpcClient.getLikedProducts(memberId, page);
+        List<SimpleProductDTO> result = productGrpcClient.getLikeProducts(memberId, page);
         ResponseDTO<List<SimpleProductDTO>> response = new ResponseDTO<>(
                 result, HttpStatus.OK, "상품 찜 목록이 20개씩 조회되었습니다.");
         return ResponseEntity.ok(response);

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/ProductMainDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/ProductMainDTO.java
@@ -1,7 +1,6 @@
 package hanium.apigateway_service.dto.product.response;
 
 import hanium.common.proto.product.CategoryMain;
-import hanium.common.proto.product.ProductMain;
 import hanium.common.proto.product.ProductMainResponse;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,27 +15,8 @@ import java.util.stream.Collectors;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductMainDTO {
 
-    List<MainProductsDTO> products;
+    List<SimpleProductDTO> products;
     List<MainCategoriesDTO> categories;
-
-    @Getter
-    @Builder
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    private static class MainProductsDTO {
-        private Long productId;
-        private String title;
-        private Long price;
-        private String imageUrl;
-
-        public static MainProductsDTO from(ProductMain message) {
-            return MainProductsDTO.builder()
-                    .productId(message.getProductId())
-                    .title(message.getTitle())
-                    .price(message.getPrice())
-                    .imageUrl(message.getImageUrl())
-                    .build();
-        }
-    }
 
     @Getter
     @Builder
@@ -58,7 +38,7 @@ public class ProductMainDTO {
                 .products(message
                         .getProductsList()
                         .stream()
-                        .map(MainProductsDTO::from)
+                        .map(SimpleProductDTO::from)
                         .collect(Collectors.toList()))
                 .categories(message
                         .getCategoriesList()

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/ProductResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/ProductResponseDTO.java
@@ -22,7 +22,8 @@ public class ProductResponseDTO {
     private Long price;
     private String category;
     private String status;
-    private boolean isSeller;
+    private boolean seller;
+    private boolean liked;
     private List<ProductImageResponseDTO> images;
 
     public static ProductResponseDTO from(ProductResponse productResponse) {
@@ -37,7 +38,8 @@ public class ProductResponseDTO {
                 .status(productResponse.getStatus())
                 .images(productResponse.getImagesList().stream().map(
                         ProductImageResponseDTO::from).collect(Collectors.toList()))
-                .isSeller(productResponse.getIsSeller())
+                .seller(productResponse.getSeller())
+                .liked(productResponse.getLiked())
                 .build();
     }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/SimpleProductDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/SimpleProductDTO.java
@@ -1,0 +1,27 @@
+package hanium.apigateway_service.dto.product.response;
+
+import hanium.common.proto.product.SimpleProductResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SimpleProductDTO {
+
+    private Long productId;
+    private String title;
+    private Long price;
+    private String imageUrl;
+
+    public static SimpleProductDTO from(SimpleProductResponse response) {
+        return SimpleProductDTO.builder()
+                .productId(response.getProductId())
+                .title(response.getTitle())
+                .price(response.getPrice())
+                .imageUrl(response.getImageUrl())
+                .build();
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/ProductGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/ProductGrpcClient.java
@@ -126,11 +126,11 @@ public class ProductGrpcClient {
     }
 
     // 상품 찜 목록 조회
-    public List<SimpleProductDTO> getLikedProducts(Long memberId, int page) {
+    public List<SimpleProductDTO> getLikeProducts(Long memberId, int page) {
         GetLikedProductsRequest grpcRequest =
                 GetLikedProductsRequest.newBuilder().setMemberId(memberId).setPage(page).build();
         try {
-            return stub.getLikedProducts(grpcRequest).getLikedProductsList()
+            return stub.getLikeProducts(grpcRequest).getLikedProductsList()
                     .stream()
                     .map(SimpleProductDTO::from)
                     .collect(Collectors.toList());

--- a/apigateway-service/src/main/java/hanium/apigateway_service/mapper/ProductGrpcMapperForGateway.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/mapper/ProductGrpcMapperForGateway.java
@@ -4,7 +4,7 @@ package hanium.apigateway_service.mapper;
 import hanium.apigateway_service.dto.product.request.RegisterProductRequestDTO;
 import hanium.apigateway_service.dto.product.request.UpdateProductRequestDTO;
 import hanium.common.proto.product.DeleteImageRequest;
-import hanium.common.proto.product.DeleteProductRequest;
+import hanium.common.proto.product.GetProductRequest;
 import hanium.common.proto.product.RegisterProductRequest;
 import hanium.common.proto.product.UpdateProductRequest;
 
@@ -48,8 +48,8 @@ public class ProductGrpcMapperForGateway {
                 .build();
     }
 
-    public static DeleteProductRequest toDeleteProductGrpc(Long productId, Long memberId) {
-        return DeleteProductRequest.newBuilder()
+    public static GetProductRequest toGetProductGrpc(Long productId, Long memberId) {
+        return GetProductRequest.newBuilder()
                 .setProductId(productId)
                 .setMemberId(memberId)
                 .build();

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -70,8 +70,9 @@ message ProductResponse {
   int64 price = 6;
   string category = 7;
   string status = 8;
-  bool is_seller = 9;
-  repeated ProductImageResponse images = 10;
+  bool seller = 9;
+  bool liked = 10;
+  repeated ProductImageResponse images = 11;
 }
 message ProductImageResponse {
   int64 product_image_id = 1;

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -22,7 +22,13 @@ service ProductService {
   rpc DeleteImage(DeleteImageRequest) returns (DeleteImageResponse);
 
   // 4. 상품 삭제
-  rpc DeleteProduct(DeleteProductRequest) returns (Empty);
+  rpc DeleteProduct(GetProductRequest) returns (Empty);
+
+  // 5. 상품 찜
+  rpc LikeProduct(GetProductRequest) returns (LikeProductResponse);
+
+  // 6. 상품 찜 목록 조회
+  rpc GetLikeProducts(GetLikedProductsRequest) returns (LikedProductsResponse);
 }
 
 message Empty {}
@@ -31,10 +37,10 @@ message ProductMainRequest {
   int64 member_id = 1;
 }
 message ProductMainResponse {
-  repeated ProductMain products = 1;
+  repeated SimpleProductResponse products = 1;
   repeated CategoryMain categories = 2;
 }
-message ProductMain {
+message SimpleProductResponse {
   int64 product_id = 1;
   string title = 2;
   int64 price = 3;
@@ -97,8 +103,16 @@ message DeleteImageResponse {
   int32 left_img_count = 1;
 }
 
-// 4. 상품 삭제
-message DeleteProductRequest {
+// 5. 상품 찜 / 찜 취소
+message LikeProductResponse {
+  bool likeCanceled = 1;
+}
+
+// 6. 상품 찜 목록 조회
+message GetLikedProductsRequest {
   int64 member_id = 1;
-  int64 product_id = 2;
+  int32 page = 2;
+}
+message LikedProductsResponse {
+  repeated SimpleProductResponse likedProducts = 1;
 }

--- a/product-service/src/main/java/hanium/product_service/domain/ProductImage.java
+++ b/product-service/src/main/java/hanium/product_service/domain/ProductImage.java
@@ -9,13 +9,19 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(
+        name = "product_image",
+        indexes = {
+                @Index(name = "idx_product_image_id_product_id", columnList = "product_id, id")
+        }
+)
 public class ProductImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "PRODUCT_ID")
+    @JoinColumn(name = "product_id")
     private Product product;
 
     // 실제 이미지 URL (S3 등 외부 저장소 경로를 저장하는 용도)

--- a/product-service/src/main/java/hanium/product_service/domain/ProductLike.java
+++ b/product-service/src/main/java/hanium/product_service/domain/ProductLike.java
@@ -1,0 +1,31 @@
+package hanium.product_service.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "product_like",
+        indexes = {
+                @Index(name = "idx_product_like_member_product", columnList = "member_id, product_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_product_like_member_product", columnNames = {"member_id", "product_id"})
+        }
+)
+public class ProductLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(nullable = false, name = "member_id")
+    private Long memberId;
+}

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProductMainDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProductMainDTO.java
@@ -1,6 +1,5 @@
 package hanium.product_service.dto.response;
 
-import hanium.product_service.domain.Product;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,27 +12,8 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductMainDTO {
 
-    List<MainProductsDTO> products;
+    List<SimpleProductDTO> products;
     List<MainCategoriesDTO> categories;
-
-    @Getter
-    @Builder
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class MainProductsDTO {
-        private Long productId;
-        private String title;
-        private Long price;
-        private String imageUrl;
-
-        public static MainProductsDTO from(Product product, String imageUrl) {
-            return MainProductsDTO.builder()
-                    .productId(product.getId())
-                    .title(product.getTitle())
-                    .price(product.getPrice())
-                    .imageUrl(imageUrl)
-                    .build();
-        }
-    }
 
     @Getter
     @Builder

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
@@ -23,9 +23,10 @@ public class ProductResponseDTO {
     private String category;
     private List<ProductImageDTO> images;
     private boolean isSeller;
+    private boolean isLiked;
 
     public static ProductResponseDTO of(String sellerNickname, Product product,
-                                        List<ProductImageDTO> images, boolean isSeller) {
+                                        List<ProductImageDTO> images, boolean isSeller, boolean liked) {
         return ProductResponseDTO.builder()
                 .productId(product.getId())
                 .title(product.getTitle())
@@ -37,6 +38,7 @@ public class ProductResponseDTO {
                 .status(product.getStatus().getLabel())
                 .images(images)
                 .isSeller(isSeller)
+                .isLiked(liked)
                 .build();
     }
 }

--- a/product-service/src/main/java/hanium/product_service/dto/response/SimpleProductDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/SimpleProductDTO.java
@@ -1,0 +1,27 @@
+package hanium.product_service.dto.response;
+
+import hanium.product_service.domain.Product;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SimpleProductDTO {
+
+    private Long productId;
+    private String title;
+    private Long price;
+    private String imageUrl;
+
+    public static SimpleProductDTO from(Product product, String imageUrl) {
+        return SimpleProductDTO.builder()
+                .productId(product.getId())
+                .title(product.getTitle())
+                .price(product.getPrice())
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/dto/response/SimpleProductDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/SimpleProductDTO.java
@@ -1,6 +1,5 @@
 package hanium.product_service.dto.response;
 
-import hanium.product_service.domain.Product;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,13 +14,4 @@ public class SimpleProductDTO {
     private String title;
     private Long price;
     private String imageUrl;
-
-    public static SimpleProductDTO from(Product product, String imageUrl) {
-        return SimpleProductDTO.builder()
-                .productId(product.getId())
-                .title(product.getTitle())
-                .price(product.getPrice())
-                .imageUrl(imageUrl)
-                .build();
-    }
 }

--- a/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
+++ b/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
@@ -6,6 +6,7 @@ import hanium.product_service.dto.response.ProductMainDTO;
 import hanium.product_service.dto.response.ProductResponseDTO;
 import hanium.product_service.dto.response.SimpleProductDTO;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class ProductGrpcMapper {
@@ -38,7 +39,7 @@ public class ProductGrpcMapper {
                 .addAllProducts(dto
                         .getProducts()
                         .stream()
-                        .map(ProductGrpcMapper::toProductMainGrpc)
+                        .map(ProductGrpcMapper::toSimpleProduct)
                         .collect(Collectors.toList()))
                 .addAllCategories(dto
                         .getCategories()
@@ -48,8 +49,8 @@ public class ProductGrpcMapper {
                 .build();
     }
 
-    private static ProductMain toProductMainGrpc(SimpleProductDTO dto) {
-        return ProductMain.newBuilder()
+    private static SimpleProductResponse toSimpleProduct(SimpleProductDTO dto) {
+        return SimpleProductResponse.newBuilder()
                 .setProductId(dto.getProductId())
                 .setTitle(dto.getTitle())
                 .setPrice(dto.getPrice())
@@ -61,6 +62,14 @@ public class ProductGrpcMapper {
         return CategoryMain.newBuilder()
                 .setName(dto.getName())
                 .setImageUrl(dto.getImageUrl())
+                .build();
+    }
+
+    public static LikedProductsResponse toLikedProductsResponse(List<SimpleProductDTO> dto) {
+        return LikedProductsResponse.newBuilder()
+                .addAllLikedProducts(dto.stream()
+                        .map(ProductGrpcMapper::toSimpleProduct)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
+++ b/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
@@ -21,7 +21,8 @@ public class ProductGrpcMapper {
                 .setSellerNickname(dto.getSellerNickname())
                 .setCategory(dto.getCategory())
                 .setStatus(dto.getStatus())
-                .setIsSeller(dto.isSeller())
+                .setSeller(dto.isSeller())
+                .setLiked(dto.isLiked())
                 .addAllImages(dto.getImages().stream().map(
                         ProductGrpcMapper::toProductImageGrpc).collect(Collectors.toList()))
                 .build();

--- a/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
+++ b/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
@@ -4,6 +4,7 @@ import hanium.common.proto.product.*;
 import hanium.product_service.dto.response.ProductImageDTO;
 import hanium.product_service.dto.response.ProductMainDTO;
 import hanium.product_service.dto.response.ProductResponseDTO;
+import hanium.product_service.dto.response.SimpleProductDTO;
 
 import java.util.stream.Collectors;
 
@@ -47,7 +48,7 @@ public class ProductGrpcMapper {
                 .build();
     }
 
-    private static ProductMain toProductMainGrpc(ProductMainDTO.MainProductsDTO dto) {
+    private static ProductMain toProductMainGrpc(SimpleProductDTO dto) {
         return ProductMain.newBuilder()
                 .setProductId(dto.getProductId())
                 .setTitle(dto.getTitle())

--- a/product-service/src/main/java/hanium/product_service/repository/ProductLikeRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductLikeRepository.java
@@ -1,0 +1,50 @@
+package hanium.product_service.repository;
+
+import hanium.product_service.domain.ProductLike;
+import hanium.product_service.repository.projection.ProductWithFirstImage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
+
+    @Modifying
+    @Query(value = "INSERT INTO likes(product_id, member_id) VALUES(:productId, :memberId)", nativeQuery = true)
+    void likeProduct(@Param("memberId") Long memberId, @Param("productId") Long productId);
+
+    @Modifying
+    @Query(value = "DELETE FROM likes WHERE product_id = :productId AND member_id  = :memberId", nativeQuery = true)
+    void unlikeProduct(@Param("memberId") Long memberId, @Param("productId") Long productId);
+
+    @Query(value = """
+            select distinct
+                likedProduct.id as productId,
+                likedProduct.title as title,
+                likedProduct.price as price,
+                singleImage.imageUrl as imageUrl
+            )
+            from ProductLike productLike
+                join productLike.product likedProduct
+                left join ProductImage singleImage
+                   on singleImage.product = likedProduct
+                   and singleImage.id = (
+                        select min(allImages.id)
+                        from ProductImage allImages
+                        where allImages.product = likedProduct
+                   )
+            where productLike.memberId = :memberId
+            order by productLike.id desc
+            """)
+    List<ProductWithFirstImage> findLikedProductsWithFirstImage(@Param("memberId") Long memberId,
+                                                                Pageable pageable);
+
+    boolean existsByProductIdAndMemberId(Long productId, Long memberId);
+
+    Long countByProductId(@Param("productId") Long productId);
+}

--- a/product-service/src/main/java/hanium/product_service/repository/ProductLikeRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductLikeRepository.java
@@ -15,15 +15,16 @@ import java.util.List;
 public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
 
     @Modifying
-    @Query(value = "INSERT INTO likes(product_id, member_id) VALUES(:productId, :memberId)", nativeQuery = true)
+    @Query(value = "INSERT INTO product_like(product_id, member_id) VALUES(:productId, :memberId)", nativeQuery = true)
     void likeProduct(@Param("memberId") Long memberId, @Param("productId") Long productId);
 
     @Modifying
-    @Query(value = "DELETE FROM likes WHERE product_id = :productId AND member_id  = :memberId", nativeQuery = true)
+    @Query(value = "DELETE FROM product_like WHERE product_id = :productId AND member_id  = :memberId", nativeQuery = true)
     void unlikeProduct(@Param("memberId") Long memberId, @Param("productId") Long productId);
 
     @Query(value = """
             select distinct
+                productLike.id as likeId,
                 likedProduct.id as productId,
                 likedProduct.title as title,
                 likedProduct.price as price,

--- a/product-service/src/main/java/hanium/product_service/repository/ProductLikeRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductLikeRepository.java
@@ -28,7 +28,6 @@ public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> 
                 likedProduct.title as title,
                 likedProduct.price as price,
                 singleImage.imageUrl as imageUrl
-            )
             from ProductLike productLike
                 join productLike.product likedProduct
                 left join ProductImage singleImage

--- a/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
@@ -2,11 +2,10 @@ package hanium.product_service.repository;
 
 import hanium.product_service.domain.Product;
 import hanium.product_service.repository.projection.ProductIdCategory;
-import jakarta.persistence.QueryHint;
-import org.hibernate.jpa.AvailableHints;
+import hanium.product_service.repository.projection.ProductWithFirstImage;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
@@ -24,6 +23,24 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             """)
     List<ProductIdCategory> findIdAndCategoryByIdIn(@Param("ids") Collection<Long> ids);
 
-    @QueryHints(@QueryHint(name = AvailableHints.HINT_READ_ONLY, value = "true"))
-    List<Product> findTop6ByOrderByCreatedAtDescIdDesc();
+    @Query("""
+            select
+                product.id as productId,
+                product.title as title,
+                product.price as price,
+                singleImage.imageUrl as imageUrl
+            from Product product
+            left join ProductImage singleImage
+                on singleImage.product = product
+               and singleImage.deletedAt is null
+               and singleImage.id = (
+                    select min(allImages.id)
+                    from ProductImage allImages
+                    where allImages.product = product
+                      and allImages.deletedAt is null
+               )
+            where product.deletedAt is null
+            order by product.createdAt desc, product.id desc
+            """)
+    List<ProductWithFirstImage> findRecentWithFirstImage(Pageable pageable);
 }

--- a/product-service/src/main/java/hanium/product_service/repository/projection/ProductWithFirstImage.java
+++ b/product-service/src/main/java/hanium/product_service/repository/projection/ProductWithFirstImage.java
@@ -1,0 +1,12 @@
+package hanium.product_service.repository.projection;
+
+public interface ProductWithFirstImage {
+
+    Long getProductId();
+
+    String getTitle();
+
+    Long getPrice();
+
+    String getImageUrl();
+}

--- a/product-service/src/main/java/hanium/product_service/service/ProductLikeService.java
+++ b/product-service/src/main/java/hanium/product_service/service/ProductLikeService.java
@@ -1,0 +1,12 @@
+package hanium.product_service.service;
+
+import hanium.product_service.dto.response.SimpleProductDTO;
+
+import java.util.List;
+
+public interface ProductLikeService {
+
+    void likeProduct(Long memberId, Long productId);
+
+    List<SimpleProductDTO> getLikedProducts(Long memberId, int page);
+}

--- a/product-service/src/main/java/hanium/product_service/service/ProductLikeService.java
+++ b/product-service/src/main/java/hanium/product_service/service/ProductLikeService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ProductLikeService {
 
-    void likeProduct(Long memberId, Long productId);
+    boolean likeProduct(Long memberId, Long productId);
 
     List<SimpleProductDTO> getLikedProducts(Long memberId, int page);
 }

--- a/product-service/src/main/java/hanium/product_service/service/ProductService.java
+++ b/product-service/src/main/java/hanium/product_service/service/ProductService.java
@@ -7,15 +7,9 @@ import hanium.product_service.dto.request.UpdateProductRequestDTO;
 import hanium.product_service.dto.response.ProductMainDTO;
 import hanium.product_service.dto.response.ProductResponseDTO;
 
-import java.util.List;
-
 public interface ProductService {
 
     ProductMainDTO getProductMain(Long memberId);
-
-    List<ProductMainDTO.MainProductsDTO> getRecentProducts();
-
-    List<ProductMainDTO.MainCategoriesDTO> getRecentCategories(Long memberId);
 
     ProductResponseDTO registerProduct(RegisterProductRequestDTO dto);
 
@@ -23,10 +17,9 @@ public interface ProductService {
 
     ProductResponseDTO getProductById(Long memberId, Long productId);
 
+    ProductResponseDTO updateProduct(UpdateProductRequestDTO dto);
+
     void deleteProductById(Long productId, Long memberId);
 
     int deleteProductImage(DeleteImageRequestDTO dto);
-
-    ProductResponseDTO updateProduct(UpdateProductRequestDTO dto);
-
 }

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductLikeServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductLikeServiceImpl.java
@@ -1,0 +1,59 @@
+package hanium.product_service.service.impl;
+
+import hanium.product_service.dto.response.SimpleProductDTO;
+import hanium.product_service.repository.ProductLikeRepository;
+import hanium.product_service.repository.projection.ProductWithFirstImage;
+import hanium.product_service.service.ProductLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductLikeServiceImpl implements ProductLikeService {
+
+    private final ProductLikeRepository likeRepository;
+
+    /**
+     * 상품을 찜 혹은 찜 취소합니다.
+     *
+     * @param memberId  요청한 사용자 id
+     * @param productId 대상 상품 id
+     */
+    @Override
+    @Transactional
+    public void likeProduct(Long memberId, Long productId) {
+        if (likeRepository.existsByProductIdAndMemberId(memberId, productId)) {
+            likeRepository.unlikeProduct(memberId, productId);
+        }
+        likeRepository.likeProduct(memberId, productId);
+    }
+
+    /**
+     * 찜한 상품을 20개씩 페이지네이션해 반환합니다.
+     *
+     * @param memberId 요청한 사용자 id
+     * @param page     요청한 페이지 number
+     * @return {id, title, price, imageUrl}로 이루어진 상품 응답 리스트
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<SimpleProductDTO> getLikedProducts(Long memberId, int page) {
+        Pageable pageable = PageRequest.of(page, 20);
+        List<ProductWithFirstImage> products =
+                likeRepository.findLikedProductsWithFirstImage(memberId, pageable);
+        // imageUrl이 null일 경우 빈 문자열로
+        return products.stream()
+                .map(p -> SimpleProductDTO.builder()
+                        .productId(p.getProductId())
+                        .title(p.getTitle())
+                        .price(p.getPrice())
+                        .imageUrl(p.getImageUrl() == null ? "" : p.getImageUrl())
+                        .build())
+                .toList();
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductLikeServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductLikeServiceImpl.java
@@ -23,14 +23,17 @@ public class ProductLikeServiceImpl implements ProductLikeService {
      *
      * @param memberId  요청한 사용자 id
      * @param productId 대상 상품 id
+     * @return 상품 찜이 취소된 것인지 여부
      */
     @Override
     @Transactional
-    public void likeProduct(Long memberId, Long productId) {
+    public boolean likeProduct(Long memberId, Long productId) {
         if (likeRepository.existsByProductIdAndMemberId(memberId, productId)) {
             likeRepository.unlikeProduct(memberId, productId);
+            return true;
         }
         likeRepository.likeProduct(memberId, productId);
+        return false;
     }
 
     /**

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductLikeServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductLikeServiceImpl.java
@@ -28,7 +28,7 @@ public class ProductLikeServiceImpl implements ProductLikeService {
     @Override
     @Transactional
     public boolean likeProduct(Long memberId, Long productId) {
-        if (likeRepository.existsByProductIdAndMemberId(memberId, productId)) {
+        if (likeRepository.existsByProductIdAndMemberId(productId, memberId)) {
             likeRepository.unlikeProduct(memberId, productId);
             return true;
         }

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductServiceImpl.java
@@ -244,7 +244,7 @@ public class ProductServiceImpl implements ProductService {
             }
         }
         if (result.size() > 4) {
-            return result.subList(0, 3);
+            return result.subList(0, 4);
         } else {
             return result;
         }

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductServiceImpl.java
@@ -11,15 +11,18 @@ import hanium.product_service.dto.request.UpdateProductRequestDTO;
 import hanium.product_service.dto.response.ProductImageDTO;
 import hanium.product_service.dto.response.ProductMainDTO;
 import hanium.product_service.dto.response.ProductResponseDTO;
+import hanium.product_service.dto.response.SimpleProductDTO;
 import hanium.product_service.grpc.ProfileGrpcClient;
 import hanium.product_service.repository.ProductImageRepository;
 import hanium.product_service.repository.ProductRepository;
 import hanium.product_service.repository.RecentViewRepository;
 import hanium.product_service.repository.projection.ProductIdCategory;
+import hanium.product_service.repository.projection.ProductWithFirstImage;
 import hanium.product_service.service.ProductService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -197,24 +200,20 @@ public class ProductServiceImpl implements ProductService {
      *
      * @return 최근 등록 게시글 리스트
      */
-    public List<ProductMainDTO.MainProductsDTO> getRecentProducts() {
-        List<Product> productList = productRepository.findTop6ByOrderByCreatedAtDescIdDesc();
-        List<ProductMainDTO.MainProductsDTO> result = new ArrayList<>();
-        for (Product product : productList) {
-            List<ProductImage> imageUrls = productImageRepository.findByProductAndDeletedAtIsNull(product);
-            String imageUrl;
-            if (imageUrls.isEmpty()) {
-                imageUrl = "";
-            } else {
-                imageUrl = imageUrls.getFirst().getImageUrl();
-            }
-            result.add(ProductMainDTO.MainProductsDTO.from(product, imageUrl));
-        }
-        if (result.size() > 6) {
-            return result.subList(0, 5);
-        } else {
-            return result;
-        }
+    private List<SimpleProductDTO> getRecentProducts() {
+        // 최근 6개만
+        PageRequest pageRequest = PageRequest.of(0, 6);
+        List<ProductWithFirstImage> products =
+                productRepository.findRecentWithFirstImage(pageRequest);
+        // imageUrl이 null일 경우 빈 문자열로
+        return products.stream()
+                .map(p -> SimpleProductDTO.builder()
+                        .productId(p.getProductId())
+                        .title(p.getTitle())
+                        .price(p.getPrice())
+                        .imageUrl(p.getImageUrl() == null ? "" : p.getImageUrl())
+                        .build())
+                .toList();
     }
 
     /**
@@ -223,7 +222,7 @@ public class ProductServiceImpl implements ProductService {
      * @param memberId 사용자 id
      * @return 최근 조회한 카테고리 목록, 4개, 형식: {이름, 아이콘 이미지 경로}
      */
-    public List<ProductMainDTO.MainCategoriesDTO> getRecentCategories(Long memberId) {
+    private List<ProductMainDTO.MainCategoriesDTO> getRecentCategories(Long memberId) {
         // 최근 조회한 상품 id 목록 조회
         List<Long> recentProductIds = recentViewRepository.getRecentProductIds(memberId);
         if (recentProductIds.isEmpty()) {

--- a/product-service/src/test/java/hanium/product_service/service/impl/ProductLikeServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/ProductLikeServiceImplTest.java
@@ -1,0 +1,98 @@
+package hanium.product_service.service.impl;
+
+import hanium.product_service.dto.response.SimpleProductDTO;
+import hanium.product_service.repository.ProductLikeRepository;
+import hanium.product_service.repository.projection.ProductWithFirstImage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ActiveProfiles("test")
+@DisplayName("상품 관심 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class ProductLikeServiceImplTest {
+
+    @Mock
+    ProductLikeRepository likeRepository;
+    @InjectMocks
+    ProductLikeServiceImpl likeService;
+
+    @Test
+    @DisplayName("관심 안 누른 상품이면 관심 등록된다")
+    void likeProduct() {
+        // given
+        given(likeRepository.existsByProductIdAndMemberId(1L, 1L)).willReturn(false);
+        // when
+        boolean result = likeService.likeProduct(1L, 1L);
+        // then
+        assertThat(result).isFalse();
+        verify(likeRepository, times(1)).likeProduct(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("관심 누른 상품이면 관심 취소된다")
+    void unlikeProduct() {
+        // given
+        given(likeRepository.existsByProductIdAndMemberId(1L, 1L)).willReturn(true);
+        // when
+        boolean result = likeService.likeProduct(1L, 1L);
+        // then
+        assertThat(result).isTrue();
+        verify(likeRepository, times(1)).unlikeProduct(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("관심 상품 목록을 조회한다")
+    void getLikedProducts() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        ProductWithFirstImage p1 = stubProduct(1L, "A", 1000L, "url");
+        ProductWithFirstImage p2 = stubProduct(2L, "B", 2000L, null);
+        given(likeRepository.findLikedProductsWithFirstImage(1L, pageable)).willReturn(List.of(p1, p2));
+        // when
+        List<SimpleProductDTO> result = likeService.getLikedProducts(1L, 0);
+        // then
+        assertThat(result).hasSize(2);
+        SimpleProductDTO dto2 = result.get(1);
+        assertThat(dto2.getProductId()).isEqualTo(2L);
+        assertThat(dto2.getImageUrl()).isEqualTo("");
+    }
+
+    private ProductWithFirstImage stubProduct(Long id, String title, Long price, String imageUrl) {
+        return new ProductWithFirstImage() {
+            @Override
+            public Long getProductId() {
+                return id;
+            }
+
+            @Override
+            public String getTitle() {
+                return title;
+            }
+
+            @Override
+            public Long getPrice() {
+                return price;
+            }
+
+            @Override
+            public String getImageUrl() {
+                return imageUrl;
+            }
+        };
+    }
+}

--- a/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verify;
 
 
 @ActiveProfiles("test")
-@DisplayName("ProductServiceImpl 테스트")
+@DisplayName("상품 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
 class ProductServiceImplTest {
 


### PR DESCRIPTION
## 💡 관련 이슈
<!-- 관련된 이슈를 연결해주세요 -->
Closes #53 

## 💼 작업 설명
<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->
상품 관심 등록, 취소 및 마이페이지의 관심 상품 목록 조회 API를 구현했습니다.

<img width="638" height="68" alt="image" src="https://github.com/user-attachments/assets/e5c71485-feab-4df8-babc-34a83e5626e3" />

## ✅ 구현/변경사항
<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
- 상품 관심 등록, 취소: 동일한 API 사용하며, 이미 관심 등록된 경우에 취소되는 분기 로직입니다.
- 관심 상품 목록 조회: 최근 관심 등록한 20개씩 페이징돼 조회하며, API의 요청 파라미터 page로 지정 가능합니다.
- 상품 상세응답과 간단응답 분리: 메인페이지 및 관심상품 등에서 사용되는 {상품ID, 제목, 가격, 첫번째 이미지 url} 형식의 SimpleProductDTO를 만들어 상세응답과 분리했습니다.
- 상품 상세응답 필드 추가: 관심 등록한 상품인지 여부를 응답에 추가했습니다.
- 메인페이지 최신 상품 6개 조회 개선: 레포지토리 쿼리를 작성해 이미지도 한 쿼리에 불러오도록 개선했습니다.

## 📝 리뷰 요구사항
<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->
- ProductLikeServiceImplTest.java 테스트 코드 
- product_service/repository/ProductLikeRepository.java 관심 상품 조회 쿼리 
- product_service/repository/ProductRepository.java 최근 등록 상품 조회 쿼리 