### PR TITLE
[refactor #56] 상품 CRUD 로직 개선, 상품 응답 수정

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/ProductResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/ProductResponseDTO.java
@@ -24,6 +24,7 @@ public class ProductResponseDTO {
     private String status;
     private boolean seller;
     private boolean liked;
+    private Long likeCount;
     private List<ProductImageResponseDTO> images;
 
     public static ProductResponseDTO from(ProductResponse productResponse) {
@@ -36,10 +37,13 @@ public class ProductResponseDTO {
                 .price(productResponse.getPrice())
                 .category(productResponse.getCategory())
                 .status(productResponse.getStatus())
-                .images(productResponse.getImagesList().stream().map(
-                        ProductImageResponseDTO::from).collect(Collectors.toList()))
                 .seller(productResponse.getSeller())
                 .liked(productResponse.getLiked())
+                .likeCount(productResponse.getLikeCount())
+                .images(productResponse.getImagesList()
+                        .stream()
+                        .map(ProductImageResponseDTO::from)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/ProductResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/product/response/ProductResponseDTO.java
@@ -17,6 +17,8 @@ public class ProductResponseDTO {
     private Long productId;
     private Long sellerId;
     private String sellerNickname;
+    private String sellerImageUrl;
+    private String createdAt;
     private String title;
     private String content;
     private Long price;
@@ -32,6 +34,8 @@ public class ProductResponseDTO {
                 .productId(productResponse.getProductId())
                 .sellerId(productResponse.getSellerId())
                 .sellerNickname(productResponse.getSellerNickname())
+                .sellerImageUrl(productResponse.getSellerProfileImg())
+                .createdAt(productResponse.getCreatedAt())
                 .title(productResponse.getTitle())
                 .content(productResponse.getContent())
                 .price(productResponse.getPrice())

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/ProductGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/ProductGrpcClient.java
@@ -5,8 +5,8 @@ import hanium.apigateway_service.dto.product.request.RegisterProductRequestDTO;
 import hanium.apigateway_service.dto.product.request.UpdateProductRequestDTO;
 import hanium.apigateway_service.dto.product.response.ProductMainDTO;
 import hanium.apigateway_service.dto.product.response.ProductResponseDTO;
-import hanium.apigateway_service.dto.product.response.SimpleProductDTO;
 import hanium.apigateway_service.dto.product.response.ProductSearchResponseDTO;
+import hanium.apigateway_service.dto.product.response.SimpleProductDTO;
 import hanium.apigateway_service.mapper.ProductGrpcMapperForGateway;
 import hanium.common.exception.CustomException;
 import hanium.common.exception.ErrorCode;
@@ -95,7 +95,7 @@ public class ProductGrpcClient {
             }
             // 새로 추가된 이미지와 수정할 상품 dto로 상품 수정
             UpdateProductRequest updateRequest =
-                    ProductGrpcMapperForGateway.toUpdateProduct2Grpc(memberId, productId, dto, s3Paths);
+                    ProductGrpcMapperForGateway.toUpdateProductGrpc(memberId, productId, dto, s3Paths);
             return ProductResponseDTO.from(stub.updateProduct(updateRequest));
 
         } catch (StatusRuntimeException e) {
@@ -180,7 +180,7 @@ public class ProductGrpcClient {
     public ProductSearchResponseDTO searchProduct(Long memberId, ProductSearchRequestDTO dto) {
         ProductSearchRequest grpcRequest =
                 ProductGrpcMapperForGateway.toSearchProductGrpc(memberId, dto);
-        try{
+        try {
             return ProductSearchResponseDTO.from(stub.searchProduct(grpcRequest));
         } catch (StatusRuntimeException e) {
             throw new CustomException(GrpcUtil.extractErrorCode(e));

--- a/apigateway-service/src/main/java/hanium/apigateway_service/mapper/ProductGrpcMapperForGateway.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/mapper/ProductGrpcMapperForGateway.java
@@ -27,9 +27,9 @@ public class ProductGrpcMapperForGateway {
                 .build();
     }
 
-    public static UpdateProductRequest toUpdateProduct2Grpc(Long memberId, Long productId,
-                                                            UpdateProductRequestDTO dto,
-                                                            List<String> s3Paths) {
+    public static UpdateProductRequest toUpdateProductGrpc(Long memberId, Long productId,
+                                                           UpdateProductRequestDTO dto,
+                                                           List<String> s3Paths) {
         return UpdateProductRequest.newBuilder()
                 .setMemberId(memberId)
                 .setProductId(productId)

--- a/common/src/main/java/hanium/common/exception/ErrorCode.java
+++ b/common/src/main/java/hanium/common/exception/ErrorCode.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public enum ErrorCode {
     INVALID_INPUT(400, "잘못된 입력입니다."),
     POST_NOT_FOUND(404, "게시글을 찾을 수 없습니다."),
-    INTERNAL_ERROR(500, "서버 오류입니다."),
+    INTERNAL_ERROR(500, "서버 오류입니다. 로그를 확인해주세요."),
 
     // -- USER-SERVICE -- //
     HAS_EMAIL(400, "이미 존재하는 이메일입니다."),
@@ -38,8 +38,8 @@ public enum ErrorCode {
     IMAGE_NOT_FOUND(404, "이미지를 찾을 수 없습니다."),
     REDIS_BOUNDZSET_ERROR(500, "레디스 연산자를 불러오는 데에 실패했습니다."),
     RECENT_VIEW_SERVER_ERROR(500, "상품 조회 기록 저장 중 오류가 발생했습니다."),
-    CHATROOM_NOT_FOUND(404,"해당 아이디를 가진 채팅방을 찾을 수 없습니다."),
-    INVALID_CHAT_IMAGE_REQUEST(404,"이미지는 최대 3장까지 가능합니다."),
+    CHATROOM_NOT_FOUND(404, "해당 아이디를 가진 채팅방을 찾을 수 없습니다."),
+    INVALID_CHAT_IMAGE_REQUEST(404, "이미지는 최대 3장까지 가능합니다."),
 
     ELASTICSEARCH_ERROR(500, "검색 중 오류가 발생했습니다."),
     ;

--- a/common/src/main/java/hanium/common/exception/GrpcUtil.java
+++ b/common/src/main/java/hanium/common/exception/GrpcUtil.java
@@ -18,21 +18,18 @@ public class GrpcUtil {
      * @return http 클라이언트로 전송할 ErrorCode
      */
     public static ErrorCode extractErrorCode(StatusRuntimeException e) {
-        log.info("✅ 서비스에서 grpc 예외 감지됨");
         Metadata metadata = Status.trailersFromThrowable(e);
         Metadata.Key<CustomError> customErrorKey = ProtoUtils.keyForProto(CustomError.getDefaultInstance());
 
         if (metadata != null) {
             CustomError customError = metadata.get(customErrorKey);
-            log.info("✅ 던져진 예외가 CustomException인 것이 확인됨, 커스텀 ErrorCode 추출 시도");
             if (customError != null) {
                 String errorName = customError.getErrorName();
-                log.info("✅ 커스텀 ErrorCode 추출됨: {}", errorName);
+                log.error("⚠️ CustomError thrown: {}", errorName);
                 return ErrorCode.valueOf(errorName);
             }
         }
-        log.info("✅ ErrorCode 추출 실패, 커스텀으로 처리될 수 있는 예외가 아닌 gRPC 오류로 추정");
-        log.error("⚠️ 실제 gPRC 오류 메시지: {}", e.getMessage());
+        log.error("⚠️ Not Customized GRPC Error: {}", e.getMessage());
         return ErrorCode.INTERNAL_ERROR;
     }
 

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -68,15 +68,17 @@ message ProductResponse {
   int64 product_id = 1;
   int64 seller_id = 2;
   string seller_nickname = 3;
-  string title = 4;
-  string content = 5;
-  int64 price = 6;
-  string category = 7;
-  string status = 8;
-  bool seller = 9;
-  bool liked = 10;
-  int64 like_count = 11;
-  repeated ProductImageResponse images = 12;
+  string seller_profile_img = 4;
+  string created_at = 5;
+  string title = 6;
+  string content = 7;
+  int64 price = 8;
+  string category = 9;
+  string status = 10;
+  bool seller = 11;
+  bool liked = 12;
+  int64 like_count = 13;
+  repeated ProductImageResponse images = 14;
 }
 message ProductImageResponse {
   int64 product_image_id = 1;

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -75,7 +75,8 @@ message ProductResponse {
   string status = 8;
   bool seller = 9;
   bool liked = 10;
-  repeated ProductImageResponse images = 11;
+  int64 like_count = 11;
+  repeated ProductImageResponse images = 12;
 }
 message ProductImageResponse {
   int64 product_image_id = 1;

--- a/common/src/main/proto/user.proto
+++ b/common/src/main/proto/user.proto
@@ -38,6 +38,9 @@ service UserService {
 
   // 9. 소셜 로그인으로 회원가입 or 로그인
   rpc SocialLogin(SocialLoginRequest) returns (TokenResponse);
+
+  // 10. 프로필 조회
+  rpc GetProfile(GetProfileRequest) returns (ProfileResponse);
 }
 
 // 1. 회원가입
@@ -136,4 +139,13 @@ message NaverConfigResponse {
 message SocialLoginRequest {
   string code = 1;
   string provider = 2;
+}
+
+// 10. 프로필 조회
+message GetProfileRequest {
+  int64 member_id = 1;
+}
+message ProfileResponse {
+  string nickname = 1;
+  string profile_img = 2;
 }

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -48,7 +48,6 @@ bootJar {
 dependencies {
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -115,6 +114,13 @@ dependencies {
 //    testImplementation("io.grpc:grpc-testing")
 //    // Spring-Test-Support (Optional)
 //    testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    // test
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 springBoot {
     mainClass = 'hanium.product_service.ProductServiceApplication'

--- a/product-service/src/main/java/hanium/product_service/domain/BaseEntity.java
+++ b/product-service/src/main/java/hanium/product_service/domain/BaseEntity.java
@@ -28,6 +28,11 @@ public class BaseEntity {
     @Column
     private LocalDateTime deletedAt;
 
+    // soft delete 처리
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
     // soft delete 확인
     public boolean isSoftDeleted() {
         return deletedAt != null;

--- a/product-service/src/main/java/hanium/product_service/domain/Category.java
+++ b/product-service/src/main/java/hanium/product_service/domain/Category.java
@@ -4,13 +4,13 @@ import lombok.Getter;
 
 @Getter
 public enum Category {
-    ELECTRONICS(0, "IT, 전자제품"),
-    FURNITURE(1, "가구, 인테리어"),
-    CLOTHES(2, "옷, 잡화, 장신구"),
-    BOOK(3, "도서, 학습 용품"),
-    BEAUTY(4, "헤어, 뷰티, 화장품"),
-    FOOD(5, "음식, 식료품"),
-    ETC(6, "기타");
+    TRAVEL(0, "이동·안전장비"),
+    FEEDING(1, "식사·수유·위생 가전"),
+    SLEEP(2, "수면·안전"),
+    PLAY(3, "놀이·교육"),
+    LIVING(4, "리빙·가구"),
+    APPAREL(5, "의류·잡화"),
+    OTHER(6, "기타");
 
     private final int index;
     private final String label;

--- a/product-service/src/main/java/hanium/product_service/domain/Product.java
+++ b/product-service/src/main/java/hanium/product_service/domain/Product.java
@@ -3,13 +3,14 @@ package hanium.product_service.domain;
 import hanium.product_service.dto.request.RegisterProductRequestDTO;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@DynamicUpdate
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(
         name = "product",
         indexes = {

--- a/product-service/src/main/java/hanium/product_service/domain/ProductLike.java
+++ b/product-service/src/main/java/hanium/product_service/domain/ProductLike.java
@@ -11,10 +11,10 @@ import lombok.*;
 @Table(
         name = "product_like",
         indexes = {
-                @Index(name = "idx_product_like_member_product", columnList = "member_id, product_id")
+                @Index(name = "idx_product_like_member_product", columnList = "product_id, member_id")
         },
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_product_like_member_product", columnNames = {"member_id", "product_id"})
+                @UniqueConstraint(name = "uq_product_like_member_product", columnNames = {"product_id", "member_id"})
         }
 )
 public class ProductLike {

--- a/product-service/src/main/java/hanium/product_service/dto/request/UpdateProductRequestDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/request/UpdateProductRequestDTO.java
@@ -15,6 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 public class UpdateProductRequestDTO {
 
+    private Long memberId;
     private Long productId;
     private String title;
     private String content;
@@ -24,6 +25,7 @@ public class UpdateProductRequestDTO {
 
     public static UpdateProductRequestDTO from(UpdateProductRequest request) {
         return UpdateProductRequestDTO.builder()
+                .memberId(request.getMemberId())
                 .productId(request.getProductId())
                 .title(request.getTitle())
                 .content(request.getContent())

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProductImageDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProductImageDTO.java
@@ -11,12 +11,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductImageDTO {
-    private Long productImageId;
+    private Long id;
     private String imageUrl;
 
     public static ProductImageDTO from(ProductImage productImage) {
         return ProductImageDTO.builder()
-                .productImageId(productImage.getId())
+                .id(productImage.getId())
                 .imageUrl(productImage.getImageUrl())
                 .build();
     }

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
@@ -1,6 +1,5 @@
 package hanium.product_service.dto.response;
 
-import hanium.product_service.domain.Product;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,33 +13,17 @@ import java.util.List;
 public class ProductResponseDTO {
 
     private Long productId;
+    private Long sellerId;
+    private String sellerNickname;
     private String title;
     private String content;
     private Long price;
-    private Long sellerId;
-    private String sellerNickname;
-    private String status;
     private String category;
+    private String status;
+    private boolean seller;
+    private boolean liked;
+    private Long likeCount;
     private List<ProductImageDTO> images;
-    private boolean isSeller;
-    private boolean isLiked;
-
-    public static ProductResponseDTO of(String sellerNickname, Product product,
-                                        List<ProductImageDTO> images, boolean isSeller, boolean liked) {
-        return ProductResponseDTO.builder()
-                .productId(product.getId())
-                .title(product.getTitle())
-                .content(product.getContent())
-                .price(product.getPrice())
-                .sellerId(product.getSellerId())
-                .sellerNickname(sellerNickname)
-                .category(product.getCategory().getLabel())
-                .status(product.getStatus().getLabel())
-                .images(images)
-                .isSeller(isSeller)
-                .isLiked(liked)
-                .build();
-    }
 
     public void updateSellerNickname(String sellerNickname) {
         this.sellerNickname = sellerNickname;

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
@@ -15,6 +15,7 @@ public class ProductResponseDTO {
     private Long productId;
     private Long sellerId;
     private String sellerNickname;
+    private String sellerProfileImg;
     private String createdAt;
     private String title;
     private String content;
@@ -26,7 +27,8 @@ public class ProductResponseDTO {
     private Long likeCount;
     private List<ProductImageDTO> images;
 
-    public void updateSellerNickname(String sellerNickname) {
-        this.sellerNickname = sellerNickname;
+    public void updateSellerProfile(ProfileResponseDTO sellerProfile) {
+        this.sellerNickname = sellerProfile.getNickname();
+        this.sellerProfileImg = sellerProfile.getProfileImageUrl();
     }
 }

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
@@ -15,6 +15,7 @@ public class ProductResponseDTO {
     private Long productId;
     private Long sellerId;
     private String sellerNickname;
+    private String createdAt;
     private String title;
     private String content;
     private Long price;

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProductResponseDTO.java
@@ -41,5 +41,8 @@ public class ProductResponseDTO {
                 .isLiked(liked)
                 .build();
     }
-}
 
+    public void updateSellerNickname(String sellerNickname) {
+        this.sellerNickname = sellerNickname;
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProfileResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProfileResponseDTO.java
@@ -1,0 +1,22 @@
+package hanium.product_service.dto.response;
+
+import hanium.common.proto.user.ProfileResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProfileResponseDTO {
+    private String nickname;
+    private String profileImageUrl;
+
+    public static ProfileResponseDTO from(ProfileResponse response) {
+        return ProfileResponseDTO.builder()
+                .nickname(response.getNickname())
+                .profileImageUrl(response.getProfileImg())
+                .build();
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/elasticsearch/ProductDocument.java
+++ b/product-service/src/main/java/hanium/product_service/elasticsearch/ProductDocument.java
@@ -14,8 +14,8 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProductDocument {
     @Id
     @Field(type = FieldType.Long)

--- a/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
@@ -60,7 +60,7 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
     @Override
     public void getProduct(GetProductRequest request, StreamObserver<ProductResponse> responseObserver) {
         try {
-            ProductResponseDTO dto = productService.getProductById(request.getMemberId(), request.getProductId());
+            ProductResponseDTO dto = productService.getProductAndViewLog(request.getMemberId(), request.getProductId());
             responseObserver.onNext(ProductGrpcMapper.toProductResponseGrpc(dto));
             responseObserver.onCompleted();
         } catch (CustomException e) {
@@ -130,7 +130,7 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
             responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
         }
     }
-    
+
     // 상품 검색
     @Override
     public void searchProduct(ProductSearchRequest request, StreamObserver<ProductSearchResponse> responseObserver) {

--- a/product-service/src/main/java/hanium/product_service/grpc/ProfileGrpcClient.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ProfileGrpcClient.java
@@ -4,7 +4,9 @@ import hanium.common.exception.CustomException;
 import hanium.common.exception.GrpcUtil;
 import hanium.common.proto.user.GetNicknameRequest;
 import hanium.common.proto.user.GetNicknameResponse;
+import hanium.common.proto.user.GetProfileRequest;
 import hanium.common.proto.user.UserServiceGrpc;
+import hanium.product_service.dto.response.ProfileResponseDTO;
 import hanium.product_service.mapper.ProfileGrpcMapper;
 import io.grpc.StatusRuntimeException;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,16 @@ public class ProfileGrpcClient {
 
         } catch (
                 StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
+
+    // 프로필 (닉네임, 사진) 조회
+    public ProfileResponseDTO getProfileByMemberId(Long memberId) {
+        try {
+            GetProfileRequest request = GetProfileRequest.newBuilder().setMemberId(memberId).build();
+            return ProfileResponseDTO.from(stub.getProfile(request));
+        } catch (StatusRuntimeException e) {
             throw new CustomException(GrpcUtil.extractErrorCode(e));
         }
     }

--- a/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
+++ b/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
@@ -13,6 +13,7 @@ public class ProductGrpcMapper {
                 .setProductId(dto.getProductId())
                 .setSellerId(dto.getSellerId())
                 .setSellerNickname(dto.getSellerNickname())
+                .setCreatedAt(dto.getCreatedAt())
                 .setTitle(dto.getTitle())
                 .setContent(dto.getContent())
                 .setPrice(dto.getPrice())

--- a/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
+++ b/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
@@ -11,17 +11,20 @@ public class ProductGrpcMapper {
     public static ProductResponse toProductResponseGrpc(ProductResponseDTO dto) {
         return ProductResponse.newBuilder()
                 .setProductId(dto.getProductId())
+                .setSellerId(dto.getSellerId())
+                .setSellerNickname(dto.getSellerNickname())
                 .setTitle(dto.getTitle())
                 .setContent(dto.getContent())
                 .setPrice(dto.getPrice())
-                .setSellerId(dto.getSellerId())
-                .setSellerNickname(dto.getSellerNickname())
                 .setCategory(dto.getCategory())
                 .setStatus(dto.getStatus())
                 .setSeller(dto.isSeller())
                 .setLiked(dto.isLiked())
-                .addAllImages(dto.getImages().stream().map(
-                        ProductGrpcMapper::toProductImageGrpc).collect(Collectors.toList()))
+                .setLikeCount(dto.getLikeCount())
+                .addAllImages(dto.getImages()
+                        .stream()
+                        .map(ProductGrpcMapper::toProductImageGrpc)
+                        .collect(Collectors.toList()))
                 .build();
     }
 

--- a/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
+++ b/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
@@ -13,6 +13,7 @@ public class ProductGrpcMapper {
                 .setProductId(dto.getProductId())
                 .setSellerId(dto.getSellerId())
                 .setSellerNickname(dto.getSellerNickname())
+                .setSellerProfileImg(dto.getSellerProfileImg())
                 .setCreatedAt(dto.getCreatedAt())
                 .setTitle(dto.getTitle())
                 .setContent(dto.getContent())

--- a/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
+++ b/product-service/src/main/java/hanium/product_service/mapper/ProductGrpcMapper.java
@@ -27,7 +27,7 @@ public class ProductGrpcMapper {
 
     private static ProductImageResponse toProductImageGrpc(ProductImageDTO dto) {
         return ProductImageResponse.newBuilder()
-                .setProductImageId(dto.getProductImageId())
+                .setProductImageId(dto.getId())
                 .setImageUrl(dto.getImageUrl())
                 .build();
     }

--- a/product-service/src/main/java/hanium/product_service/repository/ProductReadRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductReadRepository.java
@@ -6,34 +6,37 @@ import hanium.product_service.repository.projection.ProductCoreProjection;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
+@Slf4j
 public class ProductReadRepository {
 
     @PersistenceContext
     private EntityManager em;
 
     public Optional<ProductResponseDTO> findById(Long productId, Long memberId) {
-        
+
         // 상품 + 좋아요
         ProductCoreProjection core;
         try {
             core = em.createQuery("""
                                     select new hanium.product_service.repository.projection.ProductCoreProjection(
                                             p.id, p.title, p.content, p.price, p.sellerId,
+                                            p.status, p.category,
                                             (select
                                             case when count(pl) > 0 then true else false end
                                                 from ProductLike pl
                                                where pl.product.id = :productId
                                                  and pl.memberId   = :memberId),
                                              case when p.sellerId = :memberId then true else false end
-                                            )
+                                    )
                                     from Product p
-                                    where p.id = :productId
+                                    where p.id = :productId and p.deletedAt is null
                                     """,
                             ProductCoreProjection.class
                     )
@@ -44,16 +47,20 @@ public class ProductReadRepository {
             return Optional.empty();
         }
 
+        log.info("✅ Product core checked: {}", core.getTitle());
+
         // 상품 + 이미지목록
         List<ProductImageDTO> images = em.createQuery("""
                                 select new hanium.product_service.dto.response.ProductImageDTO(i.id, i.imageUrl)
                                 from ProductImage i
-                                where i.product.id = :productId
+                                where i.deletedAt is null and i.product.id = :productId
                                 order by i.id asc
                                 """,
                         ProductImageDTO.class)
                 .setParameter("productId", productId)
                 .getResultList();
+
+        log.info("✅ Product image checked: {}", images);
 
         // 응답 반환
         ProductResponseDTO response = ProductResponseDTO.builder()
@@ -68,6 +75,8 @@ public class ProductReadRepository {
                 .isSeller(core.isSeller())
                 .images(images)
                 .build();
+
+        log.info("✅ ProductResponseDTO built: {}", response);
         return Optional.of(response);
     }
 }

--- a/product-service/src/main/java/hanium/product_service/repository/ProductReadRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductReadRepository.java
@@ -1,0 +1,73 @@
+package hanium.product_service.repository;
+
+import hanium.product_service.dto.response.ProductImageDTO;
+import hanium.product_service.dto.response.ProductResponseDTO;
+import hanium.product_service.repository.projection.ProductCoreProjection;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class ProductReadRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public Optional<ProductResponseDTO> findById(Long productId, Long memberId) {
+        
+        // 상품 + 좋아요
+        ProductCoreProjection core;
+        try {
+            core = em.createQuery("""
+                                    select new hanium.product_service.repository.projection.ProductCoreProjection(
+                                            p.id, p.title, p.content, p.price, p.sellerId,
+                                            (select
+                                            case when count(pl) > 0 then true else false end
+                                                from ProductLike pl
+                                               where pl.product.id = :productId
+                                                 and pl.memberId   = :memberId),
+                                             case when p.sellerId = :memberId then true else false end
+                                            )
+                                    from Product p
+                                    where p.id = :productId
+                                    """,
+                            ProductCoreProjection.class
+                    )
+                    .setParameter("productId", productId)
+                    .setParameter("memberId", memberId)
+                    .getSingleResult();
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+
+        // 상품 + 이미지목록
+        List<ProductImageDTO> images = em.createQuery("""
+                                select new hanium.product_service.dto.response.ProductImageDTO(i.id, i.imageUrl)
+                                from ProductImage i
+                                where i.product.id = :productId
+                                order by i.id asc
+                                """,
+                        ProductImageDTO.class)
+                .setParameter("productId", productId)
+                .getResultList();
+
+        // 응답 반환
+        ProductResponseDTO response = ProductResponseDTO.builder()
+                .productId(core.getId())
+                .sellerId(core.getSellerId())
+                .title(core.getTitle())
+                .content(core.getContent())
+                .price(core.getPrice())
+                .status(core.getStatus().getLabel())
+                .category(core.getCategory().getLabel())
+                .isLiked(core.isLiked())
+                .isSeller(core.isSeller())
+                .images(images)
+                .build();
+        return Optional.of(response);
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/repository/ProductReadRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductReadRepository.java
@@ -47,8 +47,6 @@ public class ProductReadRepository {
             return Optional.empty();
         }
 
-        log.info("✅ Product core checked: {}", core.getTitle());
-
         // 상품 + 이미지목록
         List<ProductImageDTO> images = em.createQuery("""
                                 select new hanium.product_service.dto.response.ProductImageDTO(i.id, i.imageUrl)
@@ -59,8 +57,6 @@ public class ProductReadRepository {
                         ProductImageDTO.class)
                 .setParameter("productId", productId)
                 .getResultList();
-
-        log.info("✅ Product image checked: {}", images);
 
         // 응답 반환
         ProductResponseDTO response = ProductResponseDTO.builder()
@@ -76,7 +72,6 @@ public class ProductReadRepository {
                 .images(images)
                 .build();
 
-        log.info("✅ ProductResponseDTO built: {}", response);
         return Optional.of(response);
     }
 }

--- a/product-service/src/main/java/hanium/product_service/repository/ProductReadRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductReadRepository.java
@@ -9,6 +9,7 @@ import jakarta.persistence.PersistenceContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,7 +28,7 @@ public class ProductReadRepository {
             core = em.createQuery("""
                                     select new hanium.product_service.repository.projection.ProductCoreProjection(
                                       p.id, p.title, p.content, p.price, p.sellerId,
-                                      p.status, p.category,
+                                      p.status, p.category, p.createdAt,
                                       /* liked */
                                       (case when sum(case when pl.memberId = :memberId then 1 else 0 end) > 0
                                             then true else false end),
@@ -41,7 +42,7 @@ public class ProductReadRepository {
                                       on pl.product = p
                                     where p.id = :productId
                                       and p.deletedAt is null
-                                    group by p.id, p.title, p.content, p.price, p.sellerId, p.status, p.category
+                                    group by p.id, p.title, p.content, p.price, p.sellerId, p.status, p.category, p.createdAt
                                     """,
                             ProductCoreProjection.class
                     )
@@ -63,10 +64,13 @@ public class ProductReadRepository {
                 .setParameter("productId", productId)
                 .getResultList();
 
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
         // 응답 반환
         ProductResponseDTO response = ProductResponseDTO.builder()
                 .productId(core.getId())
                 .sellerId(core.getSellerId())
+                .createdAt(core.getCreatedAt().format(formatter))
                 .title(core.getTitle())
                 .content(core.getContent())
                 .price(core.getPrice())

--- a/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
@@ -21,7 +21,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("""
             select p.id as id, p.category as category
             from Product p
-            where p.id in :ids and p.deletedAt is null
+            where p.id in :ids
+              and p.deletedAt is null
             """)
     List<ProductIdCategory> findIdAndCategoryByIdIn(@Param("ids") Collection<Long> ids);
 

--- a/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
@@ -1,5 +1,6 @@
 package hanium.product_service.repository;
 
+import hanium.product_service.domain.Category;
 import hanium.product_service.domain.Product;
 import hanium.product_service.repository.projection.ProductIdCategory;
 import hanium.product_service.repository.projection.ProductWithFirstImage;
@@ -79,5 +80,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
                          @Param("title") String title,
                          @Param("content") String content,
                          @Param("price") Long price,
-                         @Param("category") String category);
+                         @Param("category") Category category);
 }

--- a/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
@@ -5,6 +5,7 @@ import hanium.product_service.repository.projection.ProductIdCategory;
 import hanium.product_service.repository.projection.ProductWithFirstImage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -63,4 +64,20 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             where product.id in :ids and product.deletedAt is null
             """)
     List<ProductWithFirstImage> findProductWithFirstImageByIds(@Param("ids") Collection<Long> ids);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Product p
+            set p.title   = :title,
+                p.content = :content,
+                p.price   = :price,
+                p.category = :category,
+                p.updatedAt = now()
+            where p.id      = :productId
+            """)
+    int updateFieldsById(@Param("productId") Long productId,
+                         @Param("title") String title,
+                         @Param("content") String content,
+                         @Param("price") Long price,
+                         @Param("category") String category);
 }

--- a/product-service/src/main/java/hanium/product_service/repository/RecentViewRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/RecentViewRepository.java
@@ -45,12 +45,12 @@ public class RecentViewRepository {
         BoundZSetOperations<Long, Long> zSet = getOperations(memberId);
         double score = (double) Instant.now().toEpochMilli();
         Boolean newlyAdded = zSet.add(productId, score);
-        // 새로 들어와서 길이가 늘어난 경우 50개 이하로 유지
+        // 새로 들어와서 길이가 늘어난 경우 30개 이하로 유지
         if (Boolean.TRUE.equals(newlyAdded)) {
             Long size = zSet.size();
-            if (size != null && size > 50) {
+            if (size != null && size > 30) {
                 // 오래된(점수 낮은) 것부터 제거
-                zSet.removeRange(0, size - 50 - 1);
+                zSet.removeRange(0, size - 30 - 1);
                 log.info("❎ 오래된 기록 삭제됨");
             }
         }
@@ -70,7 +70,6 @@ public class RecentViewRepository {
         if (members == null || members.isEmpty()) {
             return Collections.emptyList();
         } else {
-            log.info("✅ 최근 조회된 상품 id 리스트 반환: {}", members.toArray());
             return new ArrayList<>(members);
         }
     }

--- a/product-service/src/main/java/hanium/product_service/repository/projection/ProductCoreProjection.java
+++ b/product-service/src/main/java/hanium/product_service/repository/projection/ProductCoreProjection.java
@@ -5,6 +5,8 @@ import hanium.product_service.domain.Status;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @AllArgsConstructor
 public class ProductCoreProjection {
@@ -15,6 +17,7 @@ public class ProductCoreProjection {
     private Long sellerId;
     private Status status;
     private Category category;
+    private LocalDateTime createdAt;
     private boolean liked;
     private Long likeCount;
     private boolean seller;

--- a/product-service/src/main/java/hanium/product_service/repository/projection/ProductCoreProjection.java
+++ b/product-service/src/main/java/hanium/product_service/repository/projection/ProductCoreProjection.java
@@ -1,0 +1,20 @@
+package hanium.product_service.repository.projection;
+
+import hanium.product_service.domain.Category;
+import hanium.product_service.domain.Status;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductCoreProjection {
+    private Long id;
+    private String title;
+    private String content;
+    private Long price;
+    private Long sellerId;
+    private Status status;
+    private Category category;
+    private boolean liked;
+    private boolean seller;
+}

--- a/product-service/src/main/java/hanium/product_service/repository/projection/ProductCoreProjection.java
+++ b/product-service/src/main/java/hanium/product_service/repository/projection/ProductCoreProjection.java
@@ -16,5 +16,6 @@ public class ProductCoreProjection {
     private Status status;
     private Category category;
     private boolean liked;
+    private Long likeCount;
     private boolean seller;
 }

--- a/product-service/src/main/java/hanium/product_service/service/ProductService.java
+++ b/product-service/src/main/java/hanium/product_service/service/ProductService.java
@@ -1,6 +1,5 @@
 package hanium.product_service.service;
 
-import hanium.product_service.domain.Product;
 import hanium.product_service.dto.request.DeleteImageRequestDTO;
 import hanium.product_service.dto.request.RegisterProductRequestDTO;
 import hanium.product_service.dto.request.UpdateProductRequestDTO;
@@ -13,9 +12,9 @@ public interface ProductService {
 
     ProductResponseDTO registerProduct(RegisterProductRequestDTO dto);
 
-    Product getProductById(Long id);
-
     ProductResponseDTO getProductById(Long memberId, Long productId);
+
+    ProductResponseDTO getProductAndViewLog(Long memberId, Long productId);
 
     ProductResponseDTO updateProduct(UpdateProductRequestDTO dto);
 

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductServiceImpl.java
@@ -10,6 +10,7 @@ import hanium.product_service.dto.request.RegisterProductRequestDTO;
 import hanium.product_service.dto.request.UpdateProductRequestDTO;
 import hanium.product_service.dto.response.ProductMainDTO;
 import hanium.product_service.dto.response.ProductResponseDTO;
+import hanium.product_service.dto.response.ProfileResponseDTO;
 import hanium.product_service.dto.response.SimpleProductDTO;
 import hanium.product_service.elasticsearch.ProductSearchIndexer;
 import hanium.product_service.grpc.ProfileGrpcClient;
@@ -101,8 +102,8 @@ public class ProductServiceImpl implements ProductService {
         log.info("✅ Product id={} 상품 정보 불러오는 중...", productId);
         ProductResponseDTO dto = productReadRepository.findById(productId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
-        String sellerNickname = profileGrpcClient.getNicknameByMemberId(dto.getSellerId());
-        dto.updateSellerNickname(sellerNickname);
+        ProfileResponseDTO sellerProfile = profileGrpcClient.getProfileByMemberId(dto.getSellerId());
+        dto.updateSellerProfile(sellerProfile);
         return dto;
     }
 

--- a/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
@@ -154,7 +154,7 @@ class ProductServiceImplTest {
                     .thenAnswer(inv -> mock(ProductImage.class));
 
             given(productReadRepository.findById(34L, 12L)).willReturn(Optional.of(res));
-            given(profileGrpcClient.getNicknameByMemberId(12L)).willReturn("피키");
+            given(profileGrpcClient.getNicknameByMemberId(res.getSellerId())).willReturn("피키");
 
             // when
             ProductResponseDTO result = sut.registerProduct(req);
@@ -164,7 +164,7 @@ class ProductServiceImplTest {
             then(productRepository).should().save(product);
             then(productImageRepository).should(times(2)).save(any(ProductImage.class));
             then(productSearchIndexer).should().index(product);
-            then(profileGrpcClient).should().getNicknameByMemberId(12L);
+            then(profileGrpcClient).should().getNicknameByMemberId(res.getSellerId());
             then(res).should().updateSellerNickname("피키");
         }
     }
@@ -176,7 +176,7 @@ class ProductServiceImplTest {
         Long memberId = 1L, productId = 2L;
         ProductResponseDTO dto = mock(ProductResponseDTO.class);
         given(productReadRepository.findById(productId, memberId)).willReturn(Optional.of(dto));
-        given(profileGrpcClient.getNicknameByMemberId(memberId)).willReturn("피키");
+        given(profileGrpcClient.getNicknameByMemberId(dto.getSellerId())).willReturn("피키");
 
         // when
         ProductResponseDTO result = sut.getProductById(memberId, productId);
@@ -205,7 +205,7 @@ class ProductServiceImplTest {
         Long memberId = 1L, productId = 2L;
         ProductResponseDTO dto = mock(ProductResponseDTO.class);
         given(productReadRepository.findById(productId, memberId)).willReturn(Optional.of(dto));
-        given(profileGrpcClient.getNicknameByMemberId(memberId)).willReturn("피키");
+        given(profileGrpcClient.getNicknameByMemberId(dto.getSellerId())).willReturn("피키");
 
         // when
         ProductResponseDTO result = sut.getProductAndViewLog(memberId, productId);
@@ -231,7 +231,7 @@ class ProductServiceImplTest {
 
         // when
         given(productRepository.updateFieldsById(
-                anyLong(), any(), any(), any(), anyString())
+                anyLong(), any(), any(), any(), any())
         ).willReturn(0);
 
         // then
@@ -256,7 +256,7 @@ class ProductServiceImplTest {
                 .build();
 
         given(productRepository.updateFieldsById(
-                dto.getProductId(), dto.getTitle(), dto.getContent(), dto.getPrice(), dto.getCategory().toString()
+                dto.getProductId(), dto.getTitle(), dto.getContent(), dto.getPrice(), dto.getCategory()
         )).willReturn(3);
 
         Product productRef = mock(Product.class);
@@ -264,7 +264,7 @@ class ProductServiceImplTest {
 
         ProductResponseDTO res = mock(ProductResponseDTO.class);
         given(productReadRepository.findById(1L, 1L)).willReturn(Optional.of(res));
-        given(profileGrpcClient.getNicknameByMemberId(1L)).willReturn("피키");
+        given(profileGrpcClient.getNicknameByMemberId(res.getSellerId())).willReturn("피키");
 
         try (MockedStatic<ProductImage> imageOf = Mockito.mockStatic(ProductImage.class)) {
             imageOf.when(() -> ProductImage.of(eq(productRef), anyString()))

--- a/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
@@ -102,9 +102,7 @@ class ProductServiceImplTest {
         Category c2 = categories[1];
         ProductIdCategory ic1 = mock(ProductIdCategory.class);
         ProductIdCategory ic2 = mock(ProductIdCategory.class);
-        given(ic1.getId()).willReturn(10L);
         given(ic1.getCategory()).willReturn(c1);
-        given(ic2.getId()).willReturn(11L);
         given(ic2.getCategory()).willReturn(c2);
         given(productRepository.findIdAndCategoryByIdIn(recentViewedProductIds)).willReturn(List.of(ic1, ic2));
 

--- a/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
@@ -102,7 +102,9 @@ class ProductServiceImplTest {
         Category c2 = categories[1];
         ProductIdCategory ic1 = mock(ProductIdCategory.class);
         ProductIdCategory ic2 = mock(ProductIdCategory.class);
+        given(ic1.getId()).willReturn(10L);
         given(ic1.getCategory()).willReturn(c1);
+        given(ic2.getId()).willReturn(11L);
         given(ic2.getCategory()).willReturn(c2);
         given(productRepository.findIdAndCategoryByIdIn(recentViewedProductIds)).willReturn(List.of(ic1, ic2));
 

--- a/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/ProductServiceImplTest.java
@@ -1,33 +1,44 @@
 package hanium.product_service.service.impl;
 
+import hanium.common.exception.CustomException;
+import hanium.common.exception.ErrorCode;
 import hanium.product_service.domain.Category;
 import hanium.product_service.domain.Product;
-import hanium.product_service.domain.Status;
+import hanium.product_service.domain.ProductImage;
 import hanium.product_service.dto.request.RegisterProductRequestDTO;
 import hanium.product_service.dto.request.UpdateProductRequestDTO;
+import hanium.product_service.dto.response.ProductMainDTO;
 import hanium.product_service.dto.response.ProductResponseDTO;
-import hanium.product_service.elasticsearch.ProductSearchElasticRepository;
+import hanium.product_service.dto.response.SimpleProductDTO;
 import hanium.product_service.elasticsearch.ProductSearchIndexer;
 import hanium.product_service.grpc.ProfileGrpcClient;
 import hanium.product_service.repository.ProductImageRepository;
+import hanium.product_service.repository.ProductReadRepository;
 import hanium.product_service.repository.ProductRepository;
-import hanium.product_service.repository.ProductSearchRepository;
-import org.junit.jupiter.api.BeforeEach;
+import hanium.product_service.repository.RecentViewRepository;
+import hanium.product_service.repository.projection.ProductIdCategory;
+import hanium.product_service.repository.projection.ProductWithFirstImage;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 
 @ActiveProfiles("test")
@@ -36,80 +47,288 @@ import static org.mockito.Mockito.verify;
 class ProductServiceImplTest {
 
     @Mock
-    ProductRepository productRepository;
+    private ProductRepository productRepository;
     @Mock
-    ProductImageRepository imageRepository;
+    private ProductImageRepository productImageRepository;
     @Mock
-    ProfileGrpcClient profileGrpcClient;
+    private RecentViewRepository recentViewRepository;
     @Mock
-    ProductSearchElasticRepository productSearchElasticRepository;
+    private ProfileGrpcClient profileGrpcClient;
     @Mock
-    ProductSearchRepository productSearchRepository;
+    private ProductSearchIndexer productSearchIndexer;
     @Mock
-    ProductSearchIndexer productSearchIndexer;
+    private ProductReadRepository productReadRepository;
+    @Mock
+    private EntityManager em;
 
-    @InjectMocks ProductServiceImpl productService;
+    @InjectMocks
+    private ProductServiceImpl sut;
 
-    Product product;
-    RegisterProductRequestDTO registerReq;
-    UpdateProductRequestDTO updateReq;
+    @Test
+    @DisplayName("상품 홈: 상품, 카테고리 기록 없음")
+    void getProductMain_noRecentProductsAndNoRecentViews() {
+        // given
+        given(productRepository.findRecentWithFirstImage(any())).willReturn(List.of());
+        given(recentViewRepository.getRecentProductIds(anyLong())).willReturn(List.of());
 
-    @BeforeEach
-    void setUp() {
-        product = Product.builder().sellerId(1L).title("title").content("content").price(1000L)
-                .category(Category.BEAUTY).status(Status.SELLING).build();
-        registerReq = RegisterProductRequestDTO.builder()
-                .sellerId(1L).title("title").content("content").price(1000L)
-                .category(Category.BEAUTY).imageUrls(new ArrayList<>()).build();
-        updateReq = UpdateProductRequestDTO.builder().productId(1L).title("title2").content("content2")
-                .price(2000L).category(Category.BOOK).imageUrls(new ArrayList<>()).build();
+        // when
+        ProductMainDTO result = sut.getProductMain(1L);
+
+        // then
+        assertThat(result.getProducts()).isEmpty();
+        assertThat(result.getCategories()).isEmpty();
+        then(productRepository).should().findRecentWithFirstImage(any());
+        then(recentViewRepository).should().getRecentProductIds(1L);
+    }
+
+    @Test
+    @DisplayName("상품 홈")
+    void getProductMain_whenRecentProductsExist_mapsViaSimpleProductDTO_andRecentCategoriesAreBuilt() {
+        // given
+        ProductWithFirstImage newProduct1 = mock(ProductWithFirstImage.class);
+        ProductWithFirstImage newProduct2 = mock(ProductWithFirstImage.class);
+        given(productRepository.findRecentWithFirstImage(any())).willReturn(List.of(newProduct1, newProduct2));
+
+        SimpleProductDTO productDto1 = mock(SimpleProductDTO.class);
+        SimpleProductDTO productDto2 = mock(SimpleProductDTO.class);
+
+        long memberId = 1L;
+        List<Long> recentViewedProductIds = List.of(10L, 11L, 10L); // 중복 확인용 10L 2개
+        given(recentViewRepository.getRecentProductIds(memberId)).willReturn(recentViewedProductIds);
+
+        // id+category 프로젝션
+        Category[] categories = Category.values();
+        Category c1 = categories[0];
+        Category c2 = categories[1];
+        ProductIdCategory ic1 = mock(ProductIdCategory.class);
+        ProductIdCategory ic2 = mock(ProductIdCategory.class);
+        given(ic1.getId()).willReturn(10L);
+        given(ic1.getCategory()).willReturn(c1);
+        given(ic2.getId()).willReturn(11L);
+        given(ic2.getCategory()).willReturn(c2);
+        given(productRepository.findIdAndCategoryByIdIn(recentViewedProductIds)).willReturn(List.of(ic1, ic2));
+
+        try (MockedStatic<SimpleProductDTO> simpleProductDTOFrom = Mockito.mockStatic(SimpleProductDTO.class)) {
+            // 프로젝션을 SimpleProductDTO로
+            simpleProductDTOFrom.when(() -> SimpleProductDTO.from(newProduct1)).thenReturn(productDto1);
+            simpleProductDTOFrom.when(() -> SimpleProductDTO.from(newProduct2)).thenReturn(productDto2);
+
+            // when
+            ProductMainDTO result = sut.getProductMain(memberId);
+
+            // then (최근 등록 상품)
+            assertThat(result.getProducts()).containsExactly(productDto1, productDto2);
+
+            // then (최근 조회 카테고리)
+            assertThat(result.getCategories()).hasSize(2);
+            String base = "https://msa-image-bucket.s3.ap-northeast-2.amazonaws.com/product_category/";
+            assertThat(result.getCategories().get(0).getName()).isEqualTo(c1.getLabel());
+            assertThat(result.getCategories().get(0).getImageUrl()).isEqualTo(base + c1.name() + ".png");
+            assertThat(result.getCategories().get(1).getName()).isEqualTo(c2.getLabel());
+            assertThat(result.getCategories().get(1).getImageUrl()).isEqualTo(base + c2.name() + ".png");
+
+            // then (메서드 호출됐는지)
+            then(productRepository).should().findRecentWithFirstImage(any());
+            then(recentViewRepository).should().getRecentProductIds(memberId);
+            then(productRepository).should().findIdAndCategoryByIdIn(recentViewedProductIds);
+        }
     }
 
     @Test
     @DisplayName("상품 등록")
     void registerProduct() {
         // given
-        given(profileGrpcClient.getNicknameByMemberId(1L)).willReturn("피키");
-        // when
-        ProductResponseDTO result = productService.registerProduct(registerReq);
-        // then
-        assertThat(result.getTitle()).isEqualTo(registerReq.getTitle());
-        assertThat(result.getSellerNickname()).isEqualTo("피키");
+        RegisterProductRequestDTO req = mock(RegisterProductRequestDTO.class);
+        ProductResponseDTO res = mock(ProductResponseDTO.class);
+        Product product = mock(Product.class);
+
+        given(req.getImageUrls()).willReturn(List.of("u1", "u2"));
+        given(req.getSellerId()).willReturn(12L);
+        given(product.getId()).willReturn(34L);
+
+        try (MockedStatic<Product> productFrom = Mockito.mockStatic(Product.class);
+             MockedStatic<ProductImage> imageFrom = Mockito.mockStatic(ProductImage.class)) {
+
+            productFrom.when(() -> Product.from(req)).thenReturn(product);
+            imageFrom.when(() -> ProductImage.of(eq(product), anyString()))
+                    .thenAnswer(inv -> mock(ProductImage.class));
+
+            given(productReadRepository.findById(34L, 12L)).willReturn(Optional.of(res));
+            given(profileGrpcClient.getNicknameByMemberId(12L)).willReturn("피키");
+
+            // when
+            ProductResponseDTO result = sut.registerProduct(req);
+
+            // then
+            assertThat(result).isSameAs(res);
+            then(productRepository).should().save(product);
+            then(productImageRepository).should(times(2)).save(any(ProductImage.class));
+            then(productSearchIndexer).should().index(product);
+            then(profileGrpcClient).should().getNicknameByMemberId(12L);
+            then(res).should().updateSellerNickname("피키");
+        }
     }
 
     @Test
     @DisplayName("상품 조회")
-    void getProduct() {
+    void getProductById_returnsDto_andUpdatesSellerNickname() {
         // given
-        given(productRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(product));
+        Long memberId = 1L, productId = 2L;
+        ProductResponseDTO dto = mock(ProductResponseDTO.class);
+        given(productReadRepository.findById(productId, memberId)).willReturn(Optional.of(dto));
+        given(profileGrpcClient.getNicknameByMemberId(memberId)).willReturn("피키");
+
         // when
-        Product found = productService.getProductById(1L);
+        ProductResponseDTO result = sut.getProductById(memberId, productId);
+
         // then
-        assertThat(found.getTitle()).isEqualTo(registerReq.getTitle());
+        assertThat(result).isSameAs(dto);
+        then(dto).should().updateSellerNickname("피키");
+    }
+
+    @Test
+    @DisplayName("상품 조회: id 없을 시 CustomException")
+    void getProductById_notFound() {
+        // given
+        given(productReadRepository.findById(anyLong(), anyLong())).willReturn(Optional.empty());
+        // when, then
+        assertThatThrownBy(() -> sut.getProductById(1L, 2L))
+                .isInstanceOfSatisfying(CustomException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PRODUCT_NOT_FOUND)
+                );
+    }
+
+    @Test
+    @DisplayName("상품 조회: 최근 조회 기록 저장")
+    void getProductAndViewLog() {
+        // given
+        Long memberId = 1L, productId = 2L;
+        ProductResponseDTO dto = mock(ProductResponseDTO.class);
+        given(productReadRepository.findById(productId, memberId)).willReturn(Optional.of(dto));
+        given(profileGrpcClient.getNicknameByMemberId(memberId)).willReturn("피키");
+
+        // when
+        ProductResponseDTO result = sut.getProductAndViewLog(memberId, productId);
+
+        // then
+        assertThat(result).isSameAs(dto);
+        then(recentViewRepository).should().add(memberId, productId);
+    }
+
+    @Test
+    @DisplayName("상품 수정: 상품 찾을 수 없음")
+    void updateProduct_whenNoRowsUpdated_throwsCustomException() {
+        // given
+        UpdateProductRequestDTO dto = UpdateProductRequestDTO.builder()
+                .memberId(1L)
+                .productId(1L)
+                .title("t")
+                .content("c")
+                .price(1000L)
+                .category(Category.BEAUTY)
+                .imageUrls(List.of("u1", "u2"))
+                .build();
+
+        // when
+        given(productRepository.updateFieldsById(
+                anyLong(), any(), any(), any(), anyString())
+        ).willReturn(0);
+
+        // then
+        assertThatThrownBy(() -> sut.updateProduct(dto))
+                .isInstanceOfSatisfying(CustomException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PRODUCT_NOT_FOUND)
+                );
     }
 
     @Test
     @DisplayName("상품 수정")
     void updateProduct() {
         // given
-        given(productRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(product));
+        UpdateProductRequestDTO dto = UpdateProductRequestDTO.builder()
+                .memberId(1L)
+                .productId(1L)
+                .title("t")
+                .content("c")
+                .price(1000L)
+                .category(Category.BEAUTY)
+                .imageUrls(List.of("u1", "u2"))
+                .build();
+
+        given(productRepository.updateFieldsById(
+                dto.getProductId(), dto.getTitle(), dto.getContent(), dto.getPrice(), dto.getCategory().toString()
+        )).willReturn(3);
+
+        Product productRef = mock(Product.class);
+        given(em.getReference(Product.class, 1L)).willReturn(productRef);
+
+        ProductResponseDTO res = mock(ProductResponseDTO.class);
+        given(productReadRepository.findById(1L, 1L)).willReturn(Optional.of(res));
         given(profileGrpcClient.getNicknameByMemberId(1L)).willReturn("피키");
-        given(imageRepository.findByProductAndDeletedAtIsNull(product)).willReturn(new ArrayList<>());
-        // when
-        ProductResponseDTO updated = productService.updateProduct(updateReq);
-        // then
-        assertThat(updated.getTitle()).isEqualTo(updateReq.getTitle());
+
+        try (MockedStatic<ProductImage> imageOf = Mockito.mockStatic(ProductImage.class)) {
+            imageOf.when(() -> ProductImage.of(eq(productRef), anyString()))
+                    .thenAnswer(inv -> mock(ProductImage.class));
+
+            // when
+            ProductResponseDTO result = sut.updateProduct(dto);
+
+            // then
+            assertThat(result).isSameAs(res);
+            then(productImageRepository).should(times(2)).save(any(ProductImage.class));
+            then(productSearchIndexer).should().index(productRef);
+            then(res).should().updateSellerNickname("피키");
+        }
+    }
+
+    @Test
+    @DisplayName("상품 삭제: 상품 찾을 수 없음")
+    void deleteProductById_notFound() {
+        // given
+        given(productRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> sut.deleteProductById(1L, 1L))
+                .isInstanceOfSatisfying(CustomException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PRODUCT_NOT_FOUND)
+                );
+    }
+
+    @Test
+    @DisplayName("상품 삭제: 권한 없음")
+    void deleteProductById_whenNoPermission_throwsCustomException() {
+        // given
+        Product product = mock(Product.class);
+        given(product.getSellerId()).willReturn(999L);
+        given(productRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(product));
+
+        // when, then
+        assertThatThrownBy(() -> sut.deleteProductById(1L, 1L))
+                .isInstanceOfSatisfying(CustomException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NO_PERMISSION)
+                );
     }
 
     @Test
     @DisplayName("상품 삭제")
-    void deleteProduct() {
+    void deleteProductById() {
         // given
-        given(productRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(product));
-        given(imageRepository.findByProductAndDeletedAtIsNull(product)).willReturn(new ArrayList<>());
+        Long productId = 1L;
+        Product product = mock(Product.class);
+        given(product.getSellerId()).willReturn(2L);
+        given(productRepository.findByIdAndDeletedAtIsNull(productId)).willReturn(Optional.of(product));
+
+        ProductImage img1 = mock(ProductImage.class);
+        ProductImage img2 = mock(ProductImage.class);
+        given(productImageRepository.findByProductAndDeletedAtIsNull(product)).willReturn(List.of(img1, img2));
+
         // when
-        productService.deleteProductById(1L, 1L);
+        sut.deleteProductById(productId, 2L);
+
         // then
-        verify(productRepository, times(1)).save(product);
+        then(product).should().softDelete();
+        then(img1).should().softDelete();
+        then(img2).should().softDelete();
+        then(productSearchIndexer).should().remove(productId);
     }
 }

--- a/user-service/src/main/java/hanium/user_service/dto/response/ProfileResponseDTO.java
+++ b/user-service/src/main/java/hanium/user_service/dto/response/ProfileResponseDTO.java
@@ -1,0 +1,22 @@
+package hanium.user_service.dto.response;
+
+import hanium.user_service.domain.Profile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProfileResponseDTO {
+    private String nickname;
+    private String profileImg;
+
+    public static ProfileResponseDTO from(Profile profile) {
+        return ProfileResponseDTO.builder()
+                .nickname(profile.getNickname())
+                .profileImg(profile.getImageUrl())
+                .build();
+    }
+}

--- a/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
+++ b/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
@@ -10,17 +10,9 @@ import hanium.user_service.dto.request.GetNicknameRequestDTO;
 import hanium.user_service.dto.request.LoginRequestDTO;
 import hanium.user_service.dto.request.SignUpRequestDTO;
 import hanium.user_service.dto.request.VerifySmsDTO;
-import hanium.user_service.dto.response.GetNicknameResponseDTO;
-import hanium.user_service.dto.response.MemberResponseDTO;
-import hanium.user_service.dto.response.NaverConfigResponseDTO;
-import hanium.user_service.dto.response.SignUpResponseDTO;
-import hanium.user_service.dto.response.TokenResponseDTO;
+import hanium.user_service.dto.response.*;
 import hanium.user_service.mapper.MemberGrpcMapper;
-import hanium.user_service.service.AuthService;
-import hanium.user_service.service.MemberService;
-import hanium.user_service.service.ProfileService;
-import hanium.user_service.service.OAuthService;
-import hanium.user_service.service.SmsService;
+import hanium.user_service.service.*;
 import hanium.user_service.util.JwtUtil;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
@@ -195,4 +187,18 @@ public class UserGrpcService extends UserServiceGrpc.UserServiceImplBase {
         }
     }
 
+    // 닉네임, 프로필사진 반환
+    @Override
+    public void getProfile(GetProfileRequest request, StreamObserver<ProfileResponse> responseObserver) {
+        try {
+            responseObserver.onNext(
+                    MemberGrpcMapper.toProfileResponse(
+                            profileService.getProfileByMemberId(request.getMemberId())
+                    )
+            );
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
 }

--- a/user-service/src/main/java/hanium/user_service/mapper/MemberGrpcMapper.java
+++ b/user-service/src/main/java/hanium/user_service/mapper/MemberGrpcMapper.java
@@ -1,10 +1,7 @@
 package hanium.user_service.mapper;
 
 import hanium.common.proto.user.*;
-import hanium.user_service.dto.response.MemberResponseDTO;
-import hanium.user_service.dto.response.NaverConfigResponseDTO;
-import hanium.user_service.dto.response.SignUpResponseDTO;
-import hanium.user_service.dto.response.TokenResponseDTO;
+import hanium.user_service.dto.response.*;
 
 import java.util.Map;
 
@@ -64,6 +61,14 @@ public class MemberGrpcMapper {
                 .setClientId(dto.getClientId())
                 .setRedirectUri(dto.getRedirectUri())
                 .setState(dto.getState())
+                .build();
+    }
+
+    // 프로필
+    public static ProfileResponse toProfileResponse(ProfileResponseDTO dto) {
+        return ProfileResponse.newBuilder()
+                .setNickname(dto.getNickname())
+                .setProfileImg(dto.getProfileImg())
                 .build();
     }
 }

--- a/user-service/src/main/java/hanium/user_service/service/ProfileService.java
+++ b/user-service/src/main/java/hanium/user_service/service/ProfileService.java
@@ -2,7 +2,10 @@ package hanium.user_service.service;
 
 import hanium.user_service.dto.request.GetNicknameRequestDTO;
 import hanium.user_service.dto.response.GetNicknameResponseDTO;
+import hanium.user_service.dto.response.ProfileResponseDTO;
 
 public interface ProfileService {
     GetNicknameResponseDTO getNicknameByMemberId(GetNicknameRequestDTO requestDTO);
+
+    ProfileResponseDTO getProfileByMemberId(Long memberId);
 }

--- a/user-service/src/main/java/hanium/user_service/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/AuthServiceImpl.java
@@ -48,9 +48,14 @@ public class AuthServiceImpl implements AuthService {
                     .isAgreeMarketing(dto.getAgreeMarketing())
                     .isAgreeThirdParty(dto.getAgreeThirdParty())
                     .build();
+
+            String imageUrl = "https://msa-image-bucket.s3.ap-northeast-2.amazonaws.com/"
+                    + "profile_image/default/default_profile.png";
             Profile profile = Profile.builder()
                     .nickname(dto.getNickname())
+                    .imageUrl(imageUrl)
                     .member(member).build();
+
             memberRepository.save(member);
             profileRepository.save(profile);
 

--- a/user-service/src/main/java/hanium/user_service/service/impl/ProfileServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/ProfileServiceImpl.java
@@ -2,8 +2,10 @@ package hanium.user_service.service.impl;
 
 import hanium.common.exception.CustomException;
 import hanium.common.exception.ErrorCode;
+import hanium.user_service.domain.Profile;
 import hanium.user_service.dto.request.GetNicknameRequestDTO;
 import hanium.user_service.dto.response.GetNicknameResponseDTO;
+import hanium.user_service.dto.response.ProfileResponseDTO;
 import hanium.user_service.repository.ProfileRepository;
 import hanium.user_service.service.ProfileService;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @Slf4j
 public class ProfileServiceImpl implements ProfileService {
+
     private final ProfileRepository profileRepository;
+
     @Override
     public GetNicknameResponseDTO getNicknameByMemberId(GetNicknameRequestDTO requestDTO) {
 
@@ -28,5 +32,13 @@ public class ProfileServiceImpl implements ProfileService {
         return GetNicknameResponseDTO.builder()
                 .nickname(nickname)
                 .build();
+    }
+
+    // 프로필 반환
+    @Override
+    public ProfileResponseDTO getProfileByMemberId(Long memberId) {
+        Profile profile = profileRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        return ProfileResponseDTO.from(profile);
     }
 }

--- a/user-service/src/test/java/hanium/user_service/service/AuthServiceImplTest.java
+++ b/user-service/src/test/java/hanium/user_service/service/AuthServiceImplTest.java
@@ -1,112 +1,256 @@
 package hanium.user_service.service;
 
 import hanium.common.exception.CustomException;
-import hanium.user_service.domain.Member;
+import hanium.common.exception.ErrorCode;
+import hanium.user_service.domain.*;
 import hanium.user_service.dto.request.LoginRequestDTO;
 import hanium.user_service.dto.request.SignUpRequestDTO;
 import hanium.user_service.dto.response.TokenResponseDTO;
 import hanium.user_service.repository.MemberRepository;
 import hanium.user_service.repository.ProfileRepository;
-import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.BeforeEach;
+import hanium.user_service.repository.RefreshTokenRepository;
+import hanium.user_service.service.impl.AuthServiceImpl;
+import hanium.user_service.util.JwtUtil;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.List;
+import java.util.Optional;
 
-@SpringBootTest
-@Transactional
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Auth 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 class AuthServiceImplTest {
 
-    private final AuthService authService;
-    private final MemberRepository memberRepository;
-    private final ProfileRepository profileRepository;
-    private SignUpRequestDTO signupDto;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    ProfileRepository profileRepository;
+    @Mock
+    RefreshTokenRepository refreshRepository;
+    @Mock
+    BCryptPasswordEncoder encoder;
+    @Mock
+    JwtUtil jwtUtil;
 
-    @Autowired
-    public AuthServiceImplTest(AuthService authService, MemberRepository memberRepository,
-                               ProfileRepository profileRepository) {
-        this.authService = authService;
-        this.memberRepository = memberRepository;
-        this.profileRepository = profileRepository;
+    @InjectMocks
+    AuthServiceImpl sut;
+
+    // 회원가입 요청 dto mock
+    private SignUpRequestDTO mockSignUpDto(
+            String email, String pw, String confirmPw,
+            String phone, String nickname,
+            Boolean agreeMarketing, Boolean agreeThirdParty
+    ) {
+        SignUpRequestDTO dto = mock(SignUpRequestDTO.class);
+        given(dto.getEmail()).willReturn(email);
+        given(dto.getPassword()).willReturn(pw);
+        given(dto.getConfirmPassword()).willReturn(confirmPw);
+        given(dto.getPhoneNumber()).willReturn(phone);
+        given(dto.getNickname()).willReturn(nickname);
+        given(dto.getAgreeMarketing()).willReturn(agreeMarketing);
+        given(dto.getAgreeThirdParty()).willReturn(agreeThirdParty);
+        return dto;
     }
 
-    @BeforeEach
-    void setUp() {
-        signupDto = SignUpRequestDTO.builder()
-                .email("email@example.com").password("test1234").confirmPassword("test1234")
-                .phoneNumber("01012341234").nickname("nickname")
-                .agreeMarketing(true).agreeThirdParty(true).build();
-        memberRepository.deleteAll();
-        profileRepository.deleteAll();
+    // 로그인 요청 dto mock
+    private LoginRequestDTO mockLoginDto(String email, String password) {
+        LoginRequestDTO dto = mock(LoginRequestDTO.class);
+        given(dto.getEmail()).willReturn(email);
+        given(dto.getPassword()).willReturn(password);
+        return dto;
     }
 
-    @Test
-    @DisplayName("정상 회원가입")
-    void signup() {
-        // given: signupDto
-        // when
-        Member savedMember = authService.signUp(signupDto);
-        // then
-        assertThat(savedMember.getId()).isNotNull();
+    @Nested
+    @DisplayName("회원가입")
+    class SignUp {
+
+        @Test
+        @DisplayName("성공: 비밀번호 인코딩, Member/Profile 저장, 필드값 검증")
+        void signUp_success() {
+            // given
+            String email = "user@example.com";
+            String rawPw = "password";
+            String encPw = "encoded";
+            String phone = "01012345678";
+            String nickname = "피키";
+            boolean agreeMkt = true;
+            boolean agree3rd = false;
+
+            SignUpRequestDTO dto = mockSignUpDto(email, rawPw, rawPw, phone, nickname, agreeMkt, agree3rd);
+
+            given(memberRepository.findByEmail(email)).willReturn(Optional.empty());
+            given(encoder.encode(rawPw)).willReturn(encPw);
+            given(memberRepository.save(any(Member.class)))
+                    .willAnswer(inv -> inv.getArgument(0));
+            given(profileRepository.save(any(Profile.class)))
+                    .willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            Member result = sut.signUp(dto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getEmail()).isEqualTo(email);
+            assertThat(result.getPassword()).isEqualTo(encPw);
+            assertThat(result.getProvider()).isEqualTo(Provider.ORIGINAL);
+            assertThat(result.getRole()).isEqualTo(Role.USER);
+
+            then(memberRepository).should(times(1)).save(any(Member.class));
+            ArgumentCaptor<Profile> profileCap = ArgumentCaptor.forClass(Profile.class);
+            then(profileRepository).should(times(1)).save(profileCap.capture());
+            assertThat(profileCap.getValue().getMember()).isSameAs(result);
+
+            then(encoder).should(times(1)).encode(rawPw);
+            then(memberRepository).should(times(1)).findByEmail(email);
+            then(jwtUtil).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("실패: 이미 가입된 이메일이면 HAS_EMAIL 예외")
+        void signUp_emailExists_throws() {
+            // given
+            String email = "user@example.com";
+            SignUpRequestDTO dto = mock(SignUpRequestDTO.class);
+            given(dto.getEmail()).willReturn(email);
+            given(memberRepository.findByEmail(email)).willReturn(Optional.of(mock(Member.class)));
+
+            // when, then
+            assertThatThrownBy(() -> sut.signUp(dto))
+                    .isInstanceOfSatisfying(CustomException.class, ex ->
+                            assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.HAS_EMAIL));
+
+            then(encoder).shouldHaveNoInteractions();
+            then(memberRepository).should(never()).save(any());
+            then(profileRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패: 비밀번호 불일치면 PASSWORD_NOT_MATCH 예외")
+        void signUp_passwordMismatch_throws() {
+            // given
+            String email = "user@example.com";
+            SignUpRequestDTO dto = mock(SignUpRequestDTO.class);
+            given(dto.getEmail()).willReturn(email);
+            given(dto.getPassword()).willReturn("pw1");
+            given(dto.getConfirmPassword()).willReturn("pw2");
+
+            given(memberRepository.findByEmail(email)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.signUp(dto))
+                    .isInstanceOfSatisfying(CustomException.class, ex ->
+                            assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PASSWORD_NOT_MATCH));
+
+            then(encoder).shouldHaveNoInteractions();
+            then(memberRepository).should(never()).save(any());
+            then(profileRepository).should(never()).save(any());
+        }
     }
 
-    @Test
-    @DisplayName("회원가입: 중복 이메일")
-    void signup_email() {
-        // given
-        SignUpRequestDTO duplicate = SignUpRequestDTO.builder()
-                .email("email@example.com").password("test1234").confirmPassword("test1234")
-                .phoneNumber("010-1234-1234").nickname("nickname")
-                .agreeMarketing(true).agreeThirdParty(true).build();
-        // when
-        authService.signUp(signupDto);
-        CustomException e = assertThrows(CustomException.class, () -> authService.signUp(duplicate));
-        // then
-        assertThat(e.getErrorCode().name()).isEqualTo("HAS_EMAIL");
-    }
+    @Nested
+    @DisplayName("로그인")
+    class Login {
 
-    @Test
-    @DisplayName("회원가입: 비밀번호 재확인 불일치")
-    void signup_password() {
-        // given
-        SignUpRequestDTO dto = SignUpRequestDTO.builder()
-                .email("email@example.com").password("test1234").confirmPassword("doesn't match")
-                .phoneNumber("01012341234").nickname("nickname")
-                .agreeMarketing(true).agreeThirdParty(true).build();
-        // when
-        CustomException e = assertThrows(CustomException.class, () -> authService.signUp(dto));
-        // then
-        assertThat(e.getErrorCode().name()).isEqualTo("PASSWORD_NOT_MATCH");
-    }
+        @Test
+        @DisplayName("성공: 기존 Refresh 없으면 삭제 없이 토큰 발급")
+        void login_success_noExistingRefresh() {
+            // given
+            String email = "login@example.com";
+            String rawPw = "pw!";
+            String encPw = "ENC";
+            LoginRequestDTO dto = mockLoginDto(email, rawPw);
 
-    @Test
-    @DisplayName("로그인: 성공")
-    void login() {
-        // given
-        authService.signUp(signupDto);
-        LoginRequestDTO dto = LoginRequestDTO.of(signupDto.getEmail(), signupDto.getPassword());
-        // when
-        TokenResponseDTO result = authService.login(dto);
-        // then
-        assertThat(result.getEmail()).isEqualTo(signupDto.getEmail());
-    }
+            Member member = mock(Member.class);
+            given(member.getPassword()).willReturn(encPw);
+            given(member.getId()).willReturn(42L);
 
-    @Test
-    @DisplayName("로그인: 실패")
-    void login_failed() {
-        // given
-        authService.signUp(signupDto);
-        LoginRequestDTO loginDto = LoginRequestDTO.of(signupDto.getEmail(), "wrong1234");
-        // when
-        CustomException e = assertThrows(CustomException.class, () ->
-                authService.login(loginDto));
-        // then
-        assertThat(e.getErrorCode().name()).isEqualTo("LOGIN_FAILED");
+            given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
+            given(encoder.matches(rawPw, encPw)).willReturn(true);
+            given(refreshRepository.findByMember(member)).willReturn(List.of());
+
+            TokenResponseDTO tokens = mock(TokenResponseDTO.class);
+            given(jwtUtil.respondTokens(member)).willReturn(tokens);
+
+            // when
+            TokenResponseDTO result = sut.login(dto);
+
+            // then
+            assertThat(result).isSameAs(tokens);
+            then(refreshRepository).should(never()).deleteAll(anyList());
+            then(jwtUtil).should(times(1)).respondTokens(member);
+        }
+
+        @Test
+        @DisplayName("성공: 기존 Refresh 있으면 모두 삭제 후 토큰 발급")
+        void login_success_withExistingRefresh() {
+            // given
+            String email = "login@example.com";
+            String rawPw = "pw!";
+            String encPw = "ENC";
+            LoginRequestDTO dto = mockLoginDto(email, rawPw);
+
+            Member member = mock(Member.class);
+            given(member.getPassword()).willReturn(encPw);
+            given(member.getId()).willReturn(1L);
+
+            given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
+            given(encoder.matches(rawPw, encPw)).willReturn(true);
+
+            List<RefreshToken> olds = List.of(mock(RefreshToken.class), mock(RefreshToken.class));
+            given(refreshRepository.findByMember(member)).willReturn(olds);
+
+            TokenResponseDTO tokens = mock(TokenResponseDTO.class);
+            given(jwtUtil.respondTokens(member)).willReturn(tokens);
+
+            // when
+            TokenResponseDTO result = sut.login(dto);
+
+            // then
+            assertThat(result).isSameAs(tokens);
+            then(refreshRepository).should(times(1)).deleteAll(olds);
+            then(jwtUtil).should(times(1)).respondTokens(member);
+        }
+
+        @Test
+        @DisplayName("실패: 이메일 없거나 비밀번호 불일치면 LOGIN_FAILED 예외")
+        void login_fail_emailNotFound_or_passwordMismatch() {
+            // case1: 이메일 없음
+            LoginRequestDTO dto1 = mockLoginDto("none@example.com", "pw");
+            given(memberRepository.findByEmail("none@example.com")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.login(dto1))
+                    .isInstanceOfSatisfying(CustomException.class,
+                            ex -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.LOGIN_FAILED));
+
+            // case2: 이메일은 있으나 패스워드 불일치
+            LoginRequestDTO dto2 = mockLoginDto("user@example.com", "bad");
+            Member member = mock(Member.class);
+            given(member.getPassword()).willReturn("ENC");
+            given(memberRepository.findByEmail("user@example.com")).willReturn(Optional.of(member));
+            given(encoder.matches("bad", "ENC")).willReturn(false);
+
+            assertThatThrownBy(() -> sut.login(dto2))
+                    .isInstanceOfSatisfying(CustomException.class,
+                            ex -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.LOGIN_FAILED));
+
+            then(jwtUtil).shouldHaveNoInteractions();
+            then(refreshRepository).should(never()).deleteAll(anyList());
+        }
     }
 }

--- a/user-service/src/test/java/hanium/user_service/service/OAuthServiceImplTest.java
+++ b/user-service/src/test/java/hanium/user_service/service/OAuthServiceImplTest.java
@@ -1,76 +1,199 @@
 package hanium.user_service.service;
 
-import hanium.user_service.domain.Member;
+import hanium.user_service.domain.*;
 import hanium.user_service.dto.response.KakaoUserResponseDTO;
 import hanium.user_service.dto.response.NaverUserResponseDTO;
 import hanium.user_service.dto.response.TokenResponseDTO;
 import hanium.user_service.repository.MemberRepository;
+import hanium.user_service.repository.ProfileRepository;
 import hanium.user_service.repository.RefreshTokenRepository;
-import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.BeforeEach;
+import hanium.user_service.service.impl.OAuthServiceImpl;
+import hanium.user_service.util.JwtUtil;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
 
-@SpringBootTest
-@Transactional
 @ActiveProfiles("test")
+@DisplayName("소셜로그인 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
 class OAuthServiceImplTest {
 
-    private final OAuthService oAuthService;
-    private final MemberRepository memberRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    ProfileRepository profileRepository;
+    @Mock
+    RefreshTokenRepository refreshRepository;
+    @Mock
+    JwtUtil jwtUtil;
 
-    private KakaoUserResponseDTO.KakaoAccount kakaoAccount;
-    private NaverUserResponseDTO.Response naverAccount;
+    @InjectMocks
+    OAuthServiceImpl sut;
 
-    @Autowired
-    public OAuthServiceImplTest(OAuthService oAuthService, MemberRepository memberRepository,
-                                RefreshTokenRepository refreshTokenRepository) {
-        this.oAuthService = oAuthService;
-        this.memberRepository = memberRepository;
-        this.refreshTokenRepository = refreshTokenRepository;
-    }
+    @Test
+    @DisplayName("카카오 신규: Member/Profile 저장 후 토큰 발급")
+    void kakaoSignupAndLogin_success() {
+        // given
+        KakaoUserResponseDTO.KakaoAccount kakaoAccount =
+                mock(KakaoUserResponseDTO.KakaoAccount.class);
+        KakaoUserResponseDTO.KakaoAccount.Profile kakaoProfile =
+                mock(KakaoUserResponseDTO.KakaoAccount.Profile.class);
 
-    @BeforeEach
-    void setUp() {
-        KakaoUserResponseDTO.KakaoAccount.Profile profile = KakaoUserResponseDTO.KakaoAccount.Profile.builder()
-                .nickName("카카오닉네임").profileImageUrl("/path/kakao_profile_image").build();
-        kakaoAccount = KakaoUserResponseDTO.KakaoAccount.builder()
-                .email("email@kakao.com").profile(profile).build();
-        naverAccount = NaverUserResponseDTO.Response.builder()
-                .email("email@naver.com").nickname("네이버닉네임").mobile("010-6789-2345")
-                .profileImage("/path/naver_profile_image").build();
+        given(kakaoAccount.getEmail()).willReturn("kakao@example.com");
+        given(kakaoProfile.getNickName()).willReturn("카카오 닉네임");
+        given(kakaoProfile.getProfileImageUrl()).willReturn("img/kakao.png");
+
+        given(memberRepository.save(any(Member.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+        given(profileRepository.save(any(Profile.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        TokenResponseDTO tokens = mock(TokenResponseDTO.class);
+        given(jwtUtil.respondTokens(any(Member.class))).willReturn(tokens);
+
+        // when
+        TokenResponseDTO result = sut.kakaoSignupAndLogin(kakaoAccount, kakaoProfile);
+
+        // then
+        assertThat(result).isSameAs(tokens);
+
+        // 저장된 객체 캡처 및 검증
+        ArgumentCaptor<Member> memberCap = ArgumentCaptor.forClass(Member.class);
+        ArgumentCaptor<Profile> profileCap = ArgumentCaptor.forClass(Profile.class);
+
+        then(memberRepository).should(times(1)).save(memberCap.capture());
+        then(profileRepository).should(times(1)).save(profileCap.capture());
+        Member savedMember = memberCap.getValue();
+        Profile savedProfile = profileCap.getValue();
+
+        assertThat(savedMember.getEmail()).isEqualTo("kakao@example.com");
+        assertThat(savedMember.getProvider()).isEqualTo(Provider.KAKAO);
+        assertThat(savedMember.getRole()).isEqualTo(Role.USER);
+
+        assertThat(savedProfile.getNickname()).isEqualTo("카카오 닉네임");
+        assertThat(savedProfile.getImageUrl()).isEqualTo("img/kakao.png");
+        assertThat(savedProfile.getMember()).isSameAs(savedMember);
+
+        then(jwtUtil).should().respondTokens(savedMember);
     }
 
     @Test
-    @DisplayName("카카오 계정으로 신규 회원가입")
-    void kakaoSignupAndLogin() {
+    @DisplayName("네이버 신규: Member/Profile 저장 후 토큰 발급")
+    void naverSignupAndLogin_success() {
+        // given
+        NaverUserResponseDTO.Response naverUser = mock(NaverUserResponseDTO.Response.class);
+        given(naverUser.getEmail()).willReturn("naver@example.com");
+        given(naverUser.getMobile()).willReturn("010-1234-5678");
+        given(naverUser.getNickname()).willReturn("네이버 닉네임");
+        given(naverUser.getProfileImage()).willReturn("img/naver.png");
+
+        given(memberRepository.save(any(Member.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+        given(profileRepository.save(any(Profile.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        TokenResponseDTO tokens = mock(TokenResponseDTO.class);
+        given(jwtUtil.respondTokens(any(Member.class))).willReturn(tokens);
+
         // when
-        TokenResponseDTO dto = oAuthService.kakaoSignupAndLogin(kakaoAccount, kakaoAccount.getProfile());
-        Member member = memberRepository.findByEmail(kakaoAccount.getEmail()).get();
+        TokenResponseDTO result = sut.naverSignupAndLogin(naverUser);
+
         // then
-        assertThat(refreshTokenRepository.findByMember(member).getFirst().getToken())
-                .isEqualTo(dto.getRefreshToken());
-        assertThat(member.getProvider().toString())
-                .isEqualTo("KAKAO");
+        assertThat(result).isSameAs(tokens);
+
+        ArgumentCaptor<Member> memberCap = ArgumentCaptor.forClass(Member.class);
+        ArgumentCaptor<Profile> profileCap = ArgumentCaptor.forClass(Profile.class);
+
+        then(memberRepository).should().save(memberCap.capture());
+        then(profileRepository).should().save(profileCap.capture());
+
+        Member savedMember = memberCap.getValue();
+        Profile savedProfile = profileCap.getValue();
+
+        assertThat(savedMember.getEmail()).isEqualTo("naver@example.com");
+        assertThat(savedMember.getPhoneNumber()).isEqualTo("01012345678"); // 하이픈 제거
+        assertThat(savedMember.getProvider()).isEqualTo(Provider.NAVER);
+        assertThat(savedMember.getRole()).isEqualTo(Role.USER);
+
+        assertThat(savedProfile.getNickname()).isEqualTo("네이버 닉네임");
+        assertThat(savedProfile.getImageUrl()).isEqualTo("img/naver.png");
+        assertThat(savedProfile.getMember()).isSameAs(savedMember);
+
+        then(jwtUtil).should().respondTokens(savedMember);
     }
 
-    @Test
-    @DisplayName("네이버 계정으로 신규 회원가입")
-    void naverSignupAndLogin() {
-        // when
-        TokenResponseDTO dto = oAuthService.naverSignupAndLogin(naverAccount);
-        Member member = memberRepository.findByEmail(naverAccount.getEmail()).get();
-        // then
-        assertThat(refreshTokenRepository.findByMember(member).getFirst().getToken())
-                .isEqualTo(dto.getRefreshToken());
-        assertThat(member.getProvider().toString())
-                .isEqualTo("NAVER");
-        assertThat(member.getPhoneNumber()).isEqualTo("01067892345");
+    @Nested
+    @DisplayName("기존 소셜 로그인 회원")
+    class ProceedSocialLogin {
+
+        @Test
+        @DisplayName("RefreshToken 없음")
+        void proceedSocialLogin_noExistingRefresh() {
+            // given
+            Member member = mock(Member.class);
+            given(refreshRepository.findByMember(member)).willReturn(List.of());
+
+            TokenResponseDTO tokens = mock(TokenResponseDTO.class);
+            given(jwtUtil.respondTokens(member)).willReturn(tokens);
+
+            // when
+            TokenResponseDTO result = ReflectionTestUtils.invokeMethod(sut, "proceedSocialLogin", member);
+
+            // then
+            assertThat(result).isSameAs(tokens);
+            then(refreshRepository).should(never()).deleteAll(anyList());
+            then(jwtUtil).should().respondTokens(member);
+        }
+
+        @Test
+        @DisplayName("RefreshToken 존재: 모두 삭제 후 토큰 발급")
+        void proceedSocialLogin_withExistingRefresh() {
+            // given
+            Member member = mock(Member.class);
+            List<RefreshToken> olds = List.of(mock(RefreshToken.class), mock(RefreshToken.class));
+            given(refreshRepository.findByMember(member)).willReturn(olds);
+
+            TokenResponseDTO tokens = mock(TokenResponseDTO.class);
+            given(jwtUtil.respondTokens(member)).willReturn(tokens);
+
+            // when
+            TokenResponseDTO result = ReflectionTestUtils.invokeMethod(sut, "proceedSocialLogin", member);
+
+            // then
+            assertThat(result).isSameAs(tokens);
+            then(refreshRepository).should().deleteAll(olds);
+            then(jwtUtil).should().respondTokens(member);
+        }
+
+        @Test
+        @DisplayName("이메일로 찾으면 proceedSocialLogin")
+        void existingMember_flow_indirect_kakao() {
+            Member existing = mock(Member.class);
+            given(refreshRepository.findByMember(existing)).willReturn(List.of());
+            given(jwtUtil.respondTokens(existing)).willReturn(mock(TokenResponseDTO.class));
+
+            // when
+            TokenResponseDTO res = ReflectionTestUtils.invokeMethod(sut, "proceedSocialLogin", existing);
+
+            // then
+            assertThat(res).isNotNull();
+            then(jwtUtil).should().respondTokens(existing);
+        }
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
<!-- 관련된 이슈를 연결해주세요 -->
Closes #56 

## 💼 작업 설명
<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->
상품 CRUD 로직을 보기 쉽게 간소화 및 JPQL을 사용해 불필요한 다수 레포지토리 호출을 줄이고 성능을 개선했습니다.
상품 업데이트에 Setter 사용했던 기존 코드를 삭제하고 대신 레포지토리 업데이트 쿼리를 이용했습니다.
진행 중, 최근 조회한 상품이 삭제되면 상품 홈 조회 시 오류가 발생하는 이슈를 발견해 해결했습니다.
상품 상세 응답에 관심(찜) 개수, 판매자 프로필사진 url, 등록 날짜를 추가했습니다.
유저 서비스 테스트코드에 Mockito 적용해 속도를 개선했습니다.

## ✅ 구현/변경사항
<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
- ProductServiceImpl 전반적인 로직 변경 
- ProductRepository에 업데이트용 쿼리 추가
- ProductReadRepository를 새로 생성하고 상품 상세 조회용 쿼리 구현
- 유저 서비스 테스트코드에 Mockito 적용
- Product-User 서비스 간 Profile 반환하는 gRPC 로직 추가 
- 상품 상세 응답 DTO에 상품 관심(찜) 카운트, 판매자 프로필사진, 등록 날짜 추가 
- 서비스 방향성에 따라 상품 카테고리 수정 및 s3에 카테고리 이미지 업데이트 
- 회원가입 시 기본 프로필사진으로 가입되도록 수정 및 s3에 기본 프로필사진 추가 

## 📝 리뷰 요구사항
<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->
광범위하게 수정이 발생하게 되어, 꼭 충돌에 유의해 빠른 시일 내에 이 버전의 코드 받아서 사용해야 할 것 같습니다. 
(상품 메인 로직의 오류 Hotfix 포함)
테스트코드용 implementation 추가된 게 있어서 **gradle 새로고침이 필요**합니다.
상품 DTO 변경사항은 노션 명세서에 업데이트했습니다.
리뷰 요구사항: ProductRepository, ProductReadRepository 쿼리 검토 