### PR TITLE
[feat #63, fix #64, refactor # 65] 채팅 기능 수정

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/ChatController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/ChatController.java
@@ -37,9 +37,8 @@ public class ChatController {
         CreateChatroomRequestDTO requestDTO = CreateChatroomRequestDTO.builder()
                 .productId(createChatroomDTO.getProductId())
                 .receiverId(createChatroomDTO.getReceiverId())
-                .senderId(memberId)
                 .build();
-        Long chatroomId = chatroomGrpcClient.createChatroom(requestDTO);
+        Long chatroomId = chatroomGrpcClient.createChatroom(requestDTO,memberId);
 
         CreateChatroomResponseDTO responseData = new CreateChatroomResponseDTO(chatroomId, "채팅방 생성 성공!");
         ResponseDTO<CreateChatroomResponseDTO> response =

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/chat/request/CreateChatroomRequestDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/chat/request/CreateChatroomRequestDTO.java
@@ -8,6 +8,5 @@ import lombok.*;
 @NoArgsConstructor
 public class CreateChatroomRequestDTO {
     private Long productId;
-    private Long senderId;
     private Long receiverId;
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/chat/response/GetMyChatroomResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/chat/response/GetMyChatroomResponseDTO.java
@@ -22,6 +22,8 @@ public class GetMyChatroomResponseDTO {
     private String latestMessage;
     private Long productId;
     private Long opponentId; //상대방 아이디
+    private String opponentProfileUrl; //상대방 프로필 아이디
+    private String opponentNickname; //상대방 프로필 닉네임
 
     public static List<GetMyChatroomResponseDTO> from(Chatroom.ListMyChatroomsResponse response) {
         return response.getItemsList().stream()
@@ -39,6 +41,8 @@ public class GetMyChatroomResponseDTO {
                         )
                         .productId(i.getProductId())
                         .opponentId(i.getOpponentId())
+                        .opponentProfileUrl(i.getOpponentProfileUrl())
+                        .opponentNickname(i.getOpponentNickname())
                         .build())
                 .toList();
     }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/ChatroomGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/ChatroomGrpcClient.java
@@ -22,9 +22,9 @@ public class ChatroomGrpcClient {
     //grpc stub
     private ChatroomServiceGrpc.ChatroomServiceBlockingStub chatroomStub;
 
-    public Long createChatroom(CreateChatroomRequestDTO dto) {
+    public Long createChatroom(CreateChatroomRequestDTO dto,Long memberId) {
         try {
-            Chatroom.CreateChatroomRequest grpcRequest = ChatGrpcMapperForGateway.toGrpc(dto);
+            Chatroom.CreateChatroomRequest grpcRequest = ChatGrpcMapperForGateway.toGrpc(dto, memberId);
 
             Chatroom.CreateChatroomResponse response = chatroomStub.createChatroom(grpcRequest);
             return response.getChatroomId();

--- a/apigateway-service/src/main/java/hanium/apigateway_service/mapper/ChatGrpcMapperForGateway.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/mapper/ChatGrpcMapperForGateway.java
@@ -8,10 +8,10 @@ import hanium.apigateway_service.dto.chat.request.CreateChatroomRequestDTO;
 public class ChatGrpcMapperForGateway {
 
     //채팅방 생성 요청 dto에서 grpc로 변환
-    public static Chatroom.CreateChatroomRequest toGrpc(CreateChatroomRequestDTO dto) {
+    public static Chatroom.CreateChatroomRequest toGrpc(CreateChatroomRequestDTO dto,Long memberId) {
         return Chatroom.CreateChatroomRequest.newBuilder()
                 .setProductId(dto.getProductId())
-                .setSenderId(dto.getSenderId())
+                .setSenderId(memberId)
                 .setReceiverId(dto.getReceiverId())
                 .build();
     }

--- a/common/src/main/proto/chatroom.proto
+++ b/common/src/main/proto/chatroom.proto
@@ -28,6 +28,8 @@ message ChatroomSummary{
   int64 productId = 4;
   int64 opponentId = 5; //상대방 아이디
   int64 latestTime = 6;
+  string opponentProfileUrl =7;
+  string opponentNickname =8;
 
 }
 message ListMyChatroomsResponse {

--- a/product-service/src/main/java/hanium/product_service/domain/Chatroom.java
+++ b/product-service/src/main/java/hanium/product_service/domain/Chatroom.java
@@ -27,15 +27,23 @@ public class Chatroom extends BaseEntity{
     @Column(length = 50)
     private String latestContent;
 
+    @Column
     private LocalDateTime latestContentTime;
 
-    public static Chatroom from(CreateChatroomRequestDTO dto, String roomName) {
+    @Column
+    private String opponentProfileUrl;
+    @Column
+    private String opponentNickname;
+
+    public static Chatroom from(CreateChatroomRequestDTO dto, String roomName,String opponentProfileUrl, String opponentNickname) {
         return Chatroom.builder()
                 .productId(dto.getProductId())
                 .senderId(dto.getSenderId())
                 .receiverId(dto.getReceiverId())
                 .latestContentTime(LocalDateTime.now())
                 .roomName(roomName)
+                .opponentProfileUrl(opponentProfileUrl)
+                .opponentNickname(opponentNickname)
                 .build();
     }
 

--- a/product-service/src/main/java/hanium/product_service/dto/response/GetMyChatroomResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/GetMyChatroomResponseDTO.java
@@ -21,6 +21,8 @@ public class GetMyChatroomResponseDTO {
     private String latestMessage;
     private Long productId;
     private Long opponentId; //상대방 아이디
+    private String opponentProfileUrl; //상대방 프로필 아이디
+    private String opponentNickname; //상대방 프로필 닉네임
 
     public static GetMyChatroomResponseDTO from(Chatroom.ChatroomSummary summary) {
         return GetMyChatroomResponseDTO.builder()

--- a/product-service/src/main/java/hanium/product_service/grpc/ChatGrpcService.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ChatGrpcService.java
@@ -55,6 +55,8 @@ public class ChatGrpcService extends ChatroomServiceGrpc.ChatroomServiceImplBase
                             .setProductId(dto.getProductId() == null ? 0L : dto.getProductId())
                             .setOpponentId(dto.getOpponentId() == null ? 0L : dto.getOpponentId())
                             .setLatestTime(latestMillis)
+                            .setOpponentProfileUrl(dto.getOpponentProfileUrl())
+                            .setOpponentNickname(dto.getOpponentNickname())
                             .build();
 
             resp.addItems(summary);

--- a/product-service/src/main/java/hanium/product_service/grpc/ChattingGrpcService.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ChattingGrpcService.java
@@ -3,6 +3,7 @@ package hanium.product_service.grpc;
 import chat.Chat;
 import chat.ChatServiceGrpc;
 import hanium.product_service.dto.response.ChatMessageResponseDTO;
+import hanium.product_service.dto.response.ProfileResponseDTO;
 import hanium.product_service.s3.PresignService;
 import hanium.product_service.service.ChatService;
 import io.grpc.Status;
@@ -59,7 +60,8 @@ public class ChattingGrpcService extends ChatServiceGrpc.ChatServiceImplBase {
         Chat.GetAllMessagesByChatroomResponse.Builder resp = Chat.GetAllMessagesByChatroomResponse.newBuilder();
 
         for (ChatMessageResponseDTO dto : allMessagesByChatroomId) {
-            String opponentNickname = profileGrpcClient.getNicknameByMemberId(dto.getReceiverId());
+
+            ProfileResponseDTO profileResponseDTO = profileGrpcClient.getProfileByMemberId(dto.getReceiverId());
 
             Chat.ChatResponseMessage.Builder responseMessage =
                     Chat.ChatResponseMessage.newBuilder()
@@ -69,7 +71,7 @@ public class ChattingGrpcService extends ChatServiceGrpc.ChatServiceImplBase {
                             .setReceiverId(dto.getReceiverId())
                             .setContent(dto.getContent())
                             .setTimestamp(dto.getTimestamp())
-                            .setReceiverNickname(opponentNickname)
+                            .setReceiverNickname(profileResponseDTO.getNickname())
                             .setType(Chat.MessageType.valueOf(dto.getType()));
 
             if (dto.getImageUrls() != null && !dto.getImageUrls().isEmpty()) {

--- a/product-service/src/main/java/hanium/product_service/grpc/ProfileGrpcClient.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ProfileGrpcClient.java
@@ -21,19 +21,6 @@ public class ProfileGrpcClient {
     @GrpcClient("user-service") //discovery:///user-service 사용
     private UserServiceGrpc.UserServiceBlockingStub stub;
 
-    public String getNicknameByMemberId(Long memberId) {
-        try {
-            GetNicknameRequest request = ProfileGrpcMapper.toGrpc(memberId);
-
-            GetNicknameResponse response = stub.getNicknameByMemberId(request);
-            return response.getNickname();
-
-        } catch (
-                StatusRuntimeException e) {
-            throw new CustomException(GrpcUtil.extractErrorCode(e));
-        }
-    }
-
     // 프로필 (닉네임, 사진) 조회
     public ProfileResponseDTO getProfileByMemberId(Long memberId) {
         try {


### PR DESCRIPTION
## 💡 관련 이슈
#63 [FEAT] 채팅방 생성 및 조회시 프로필 이미지 추가
#64 [FIX] 상대방 닉네임 조회 getNicknameByMemberId 에서 getProfile로 수정 
#65  [REFACTOR] 채팅방 생성시 CreateChatroomRequestDTO에 senderId 제외

## 💼 작업 설명

- 기존 채팅 로직
  - ChatMessageResponseDTO 채팅메시지 dto에 상대방 닉네임 필드 존재 
     -> 메시지를 조회할때마다 프로필에서 닉네임을 가져오게되는 쿼리가 날라감 -> 메시지가 많아지면 성능에 안좋을 것으로 예상됨.  
  - 채팅방 생성시 senderId를 요청dto에 넣어주는 것은 보안에 취약할 것으로 예상이 되어 리팩토링
  - 이미 Authentication에서 받아서 memberId를 추출하기때문에 필요하지 않은 필드

- 수정 후 채팅 로직 
    -  채팅방 생성 및 조회할 때 상대방 프로필 이미지랑 닉네임을 저장하고 조회
    - 채팅방 생성 요청 dto에서 senderId 삭제

## ✅ 구현/변경사항

apigateway-service
- GetMyChatroomResponseDTO
- chatroom.proto

common
- chatroom.proto

product-service
- Chatroom
- GetMyChatroomResponseDTO
- ChatGrpcService
- ChatServiceImpl
- ChattingGrpcService
- ProfileGrpcClient

- [x] 채팅 생성 시 데이터베이스에 프로필 이미지 저장

- [x] 내가 참여한 채팅방 리스트 조회 api 응답에 상대방 프로필 이미지와 상대방 닉네임 응답 추가

- [x] 프로필 API 작업 전에 임의로 해둔 getNickNameByMemeberId를 getProfile로 교체 및 getNickNameByMemberId 메서드 삭제
- [x]  CreateChatroomRequestDTO에 senderId 제외

노션 api 명세서 업데이트 완료했습니다.

<img width="735" height="878" alt="image" src="https://github.com/user-attachments/assets/ba053b6f-6dc5-43e8-a99f-a4115377d870" />


## 📝 리뷰 요구사항
