### PR TITLE
[fest #68] 채팅방 이름 생성 로직, 채팅방 존재 유무 로직 수정

### DIFF
--- a/product-service/src/main/java/hanium/product_service/domain/Chatroom.java
+++ b/product-service/src/main/java/hanium/product_service/domain/Chatroom.java
@@ -16,8 +16,6 @@ public class Chatroom extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column
-    private String roomName;
-    @Column
     private Long productId;
     @Column
     private Long senderId;
@@ -30,20 +28,17 @@ public class Chatroom extends BaseEntity{
     @Column
     private LocalDateTime latestContentTime;
 
-    @Column
-    private String opponentProfileUrl;
-    @Column
-    private String opponentNickname;
+//    @Column
+//    private String opponentProfileUrl;
+//    @Column
+//    private String opponentNickname;
 
-    public static Chatroom from(CreateChatroomRequestDTO dto, String roomName,String opponentProfileUrl, String opponentNickname) {
+    public static Chatroom from(CreateChatroomRequestDTO dto) {
         return Chatroom.builder()
                 .productId(dto.getProductId())
                 .senderId(dto.getSenderId())
                 .receiverId(dto.getReceiverId())
                 .latestContentTime(LocalDateTime.now())
-                .roomName(roomName)
-                .opponentProfileUrl(opponentProfileUrl)
-                .opponentNickname(opponentNickname)
                 .build();
     }
 

--- a/product-service/src/main/java/hanium/product_service/repository/ChatroomRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ChatroomRepository.java
@@ -2,20 +2,22 @@ package hanium.product_service.repository;
 
 import hanium.product_service.domain.Chatroom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
-    
     //해당 채팅방 존재 여부 확인
-    Optional<Chatroom> findByProductIdAndSenderIdAndReceiverId(Long productId, Long senderId, Long receiverId);
-
-//    //채팅방 별 최근 채팅 메시지 및 시간 업데이트
-//    @Query("update Chatroom c set c.latestContent = :content, c.latestContentTime = :time where c.id= :chatroomId")
-//    void updateLatest(@Param("chatroomId") Long chatroomId, @Param("content") String content, @Param("time") LocalDateTime time);
-
+    @Query("""
+            select c from Chatroom c
+            where c.productId = :productId
+              and(
+              c.senderId= :senderId and c.receiverId = :receiverId)
+              or(c.senderId= :receiverId and c.receiverId =:senderId)
+            """)
+    Optional<Chatroom> findByProductIdAndMembers(Long productId, Long senderId, Long receiverId);
 
     // 내가 sender거나 receiver인 채팅방을 최신 대화시간 내림차순으로
     List<Chatroom> findBySenderIdOrReceiverIdOrderByLatestContentTimeDesc(Long senderId, Long receiverId);


### PR DESCRIPTION
## 💡 관련 이슈
Closes #68 

## 💼 작업 설명

- 채팅방 이름 생성 : 각 채팅방 상대 닉네임/상품 이름 으로 구성
- 채팅방 존재 유무 확인 쿼리 : 기존 - 단방향 검증, 수정 후 : 양방향 검증

## ✅ 구현/변경사항
- Chatroom Entity:  굳이 상대방 프로필 이미지와 닉네임을 저장할 필요가 없어서 삭제
- ChatroomRepository : sender/receiver 양방향 조건 때문에 메서드 네이밍으로 표현하기가 애매 -> @Query 선택

- ChatServiceImpl : 채팅방 생성할 때는 프로필 엔티티 접근 X -> 조회할 때 프로필에 접근하여 응답 DTO에 담아주도록 수정 

## 📝 리뷰 요구사항

- 성능 부분에서 최적화할 수 있는 부분 리뷰해주시면 감사하겠습니다 👍  