### PR TITLE
[feat/#73] 상품 검색 결과 정렬 기능 추가 (최신순/인기순)

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/ProductController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/ProductController.java
@@ -142,7 +142,10 @@ public class ProductController {
     @GetMapping("/search/{keyword}")
     public ResponseEntity<ResponseDTO<ProductSearchResponseDTO>> searchProduct(
             @PathVariable ("keyword") String keyword,
-            Authentication authentication) {
+            Authentication authentication,
+            @RequestParam(defaultValue = "recent") String sort,
+            @RequestParam(defaultValue = "0") int page
+    ) {
 
         Long memberId = (Long) authentication.getPrincipal();
 
@@ -150,10 +153,11 @@ public class ProductController {
                 .keyword(keyword)
                 .build();
 
-        ProductSearchResponseDTO result = productGrpcClient.searchProduct(memberId, requestDTO);
+        ProductSearchResponseDTO result = productGrpcClient.searchProduct(memberId, requestDTO, sort, page);
 
         ResponseDTO<ProductSearchResponseDTO> response = new ResponseDTO<>(
-                result, HttpStatus.OK, "상품 검색 결과입니다.");
+                result, HttpStatus.OK,
+                "[" + requestDTO.getKeyword() + "]를 [" + sort + "]순으로 검색하였습니다.");
 
         return ResponseEntity.ok(response);
     }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/ProductGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/ProductGrpcClient.java
@@ -190,9 +190,9 @@ public class ProductGrpcClient {
     }
 
     // 상품 검색
-    public ProductSearchResponseDTO searchProduct(Long memberId, ProductSearchRequestDTO dto) {
+    public ProductSearchResponseDTO searchProduct(Long memberId, ProductSearchRequestDTO dto, String sort, int page) {
         ProductSearchRequest grpcRequest =
-                ProductGrpcMapperForGateway.toSearchProductGrpc(memberId, dto);
+                ProductGrpcMapperForGateway.toSearchProductGrpc(memberId, dto, sort, page);
         try {
             return ProductSearchResponseDTO.from(stub.searchProduct(grpcRequest));
         } catch (StatusRuntimeException e) {

--- a/apigateway-service/src/main/java/hanium/apigateway_service/mapper/ProductGrpcMapperForGateway.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/mapper/ProductGrpcMapperForGateway.java
@@ -54,10 +54,13 @@ public class ProductGrpcMapperForGateway {
                 .build();
     }
 
-    public static ProductSearchRequest toSearchProductGrpc(Long memberId, ProductSearchRequestDTO dto) {
+    public static ProductSearchRequest toSearchProductGrpc(Long memberId, ProductSearchRequestDTO dto, String sort, int page) {
         return ProductSearchRequest.newBuilder()
                 .setMemberId(memberId)
                 .setKeyword(dto.getKeyword())
+                .setSort(sort)
+                .setPage(page)
+
                 .build();
     }
 

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -143,6 +143,8 @@ message LikedProductsResponse {
 message ProductSearchRequest {
   int64 member_id = 1;
   string keyword = 2;
+  string sort = 3;
+  int32 page = 4;
 }
 message ProductSearchResponse {
   repeated SimpleProductResponse productList = 1;

--- a/product-service/src/main/java/hanium/product_service/dto/request/ProductSearchRequestDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/request/ProductSearchRequestDTO.java
@@ -13,11 +13,15 @@ import lombok.NoArgsConstructor;
 public class ProductSearchRequestDTO {
     private Long memberId;
     private String keyword;
+    private String sort;
+    private int page;
 
     public static ProductSearchRequestDTO from(ProductSearchRequest request) {
         return ProductSearchRequestDTO.builder()
                 .memberId(request.getMemberId())
                 .keyword(request.getKeyword())
+                .sort(request.getSort())
+                .page(request.getPage())
                 .build();
 
     }

--- a/product-service/src/main/java/hanium/product_service/dto/response/ProductSearchResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/ProductSearchResponseDTO.java
@@ -19,4 +19,6 @@ public class ProductSearchResponseDTO {
                 .productList(list)
                 .build();
     }
+
+
 }

--- a/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
@@ -147,4 +147,72 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     )
     List<ProductWithFirstImage> findProductByCategoryAndSortByLike(@Param("category") String category,
                                                                    Pageable pageable);
+
+    @Query(
+            value = """
+                    select p.id as productId, p.title as title, p.price as price, i.image_url as imageUrl
+                    from product p
+                    left join (
+                        select product_id, min(id) as min_image_id
+                        from product_image
+                        where deleted_at is null
+                        group by product_id
+                    ) min_image_table on min_image_table.product_id = p.id
+                    left join product_image i on i.id = min_image_table.min_image_id
+                    where p.id in :ids and p.deleted_at is null
+                    order by p.created_at desc, p.id desc
+                    """,
+            countQuery = """
+                         select count(*)
+                         from product p
+                         where p.id in :ids
+                         and p.deleted_at is null
+
+                         """,
+            nativeQuery = true)
+    List<ProductWithFirstImage> findProductByIdsAndSortByRecent(
+            @Param("ids") List<Long> ids,
+            Pageable pageable
+    );
+
+
+    @Query(
+            value = """
+                    select p.id as productId, p.title as title, p.price as price, fi.image_url as imageUrl
+                    from product p
+                    /* 상품별 ProductLike 카운트한 lc 테이블 조인 */
+                    left join (
+                        select pl.product_id, count(*) as like_count
+                        from product_like pl
+                        group by pl.product_id
+                    ) lc on lc.product_id = p.id
+                    /* fi 테이블에서 실제 가져온 상품 p에 맞는 이미지만 선택 (조인) */
+                    left join (
+                        select x.product_id, pi.image_url
+                        /* 상품별 첫 번째 ProductImage만 가져온 x 테이블로 */
+                        /* pi 테이블에서 첫 번째 이미지 url만 선택 -> fi 테이블 */
+                        from (
+                            select product_id, MIN(id) AS first_image
+                            from product_image
+                            group by product_id
+                        ) x
+                        join product_image pi
+                          on pi.id = x.first_image
+                    ) fi on fi.product_id = p.id
+                    where p.id in :ids and p.deleted_at is null
+                      and p.created_at >= NOW() - interval 1 year
+                    order by coalesce(lc.like_count, 0) desc, p.id desc
+                    """,
+            countQuery = """
+                         select count(*)
+                         from product p
+                         where p.id in :ids
+                         and p.deleted_at is null
+                         and p.created_at >= NOW() - interval 1 year
+                         """,
+            nativeQuery = true)
+    List<ProductWithFirstImage> findProductByIdsAndSortByLike(
+            @Param("ids") List<Long> ids,
+            Pageable pageable
+    );
 }

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductSearchServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductSearchServiceImpl.java
@@ -70,10 +70,6 @@ public class ProductSearchServiceImpl implements ProductSearchService {
         List<ProductWithFirstImage> products;
         Pageable pageable = PageRequest.of(dto.getPage(), 20);
 
-//        if (ids.isEmpty()) {
-//            return ProductSearchResponseDTO.from(Collections.EMPTY_LIST);
-//        }
-
         if(dto.getSort().equals("recent")) {
             log.info("✅ 키워드 검색 [{}] 최신순 조회 호출", dto.getKeyword());
             products = productRepository.findProductByIdsAndSortByRecent(ids,pageable);

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductSearchServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductSearchServiceImpl.java
@@ -3,7 +3,6 @@ package hanium.product_service.service.impl;
 import hanium.common.exception.CustomException;
 import hanium.common.exception.ErrorCode;
 import hanium.product_service.domain.ProductSearch;
-import hanium.product_service.dto.request.GetProductByCategoryRequestDTO;
 import hanium.product_service.dto.request.ProductSearchRequestDTO;
 import hanium.product_service.dto.response.ProductSearchHistoryDTO;
 import hanium.product_service.dto.response.ProductSearchResponseDTO;
@@ -21,7 +20,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -72,9 +70,9 @@ public class ProductSearchServiceImpl implements ProductSearchService {
         List<ProductWithFirstImage> products;
         Pageable pageable = PageRequest.of(dto.getPage(), 20);
 
-        if (ids.isEmpty()) {
-            return ProductSearchResponseDTO.from(Collections.EMPTY_LIST);
-        }
+//        if (ids.isEmpty()) {
+//            return ProductSearchResponseDTO.from(Collections.EMPTY_LIST);
+//        }
 
         if(dto.getSort().equals("recent")) {
             log.info("✅ 키워드 검색 [{}] 최신순 조회 호출", dto.getKeyword());


### PR DESCRIPTION
## 💡 관련 이슈
Closes #73 

## 💼 작업 설명
* 상품 검색 결과에 최신순, 인기순 정렬 기능을 추가
* 정렬 기준은 쿼리 파라미터 sort를 통해 전달
* 기본값은 최신순

## ✅ 구현/변경사항
* gateway : ProductController @RequestParam으로 'sort'와 'page' 파라미터 추가
* ProductRepository : 두 개의 Native Query 기반 메서드를 추가
  `findProductByIdsAndSortByRecent `
  정렬 기준 : p.created_at desc, p.id desc
  `findProductByIdsAndSortByLike`
  정렬 기준 : like_count desc, p.id desc

## 📝 리뷰 요구사항
@mminjukim Query 작성 방식의 가독성 및 성능에 대해서 리뷰 부탁드립니다🤓