### PR TITLE
[feat #79] 마이페이지 프로필 기능 구현

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/UserController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/UserController.java
@@ -160,7 +160,7 @@ public class UserController {
     }
 
     // 프로필 수정
-    @PutMapping("my-profile")
+    @PutMapping("/my-profile")
     public ResponseEntity<ResponseDTO<ProfileResponseDTO>> updateProfile(Authentication authentication,
                                                                          @RequestBody UpdateProfileRequestDTO dto) {
         Long memberId = (Long) authentication.getPrincipal();
@@ -172,13 +172,31 @@ public class UserController {
     }
 
     // (마이페이지) 프로필 상세 조회
-    @GetMapping("my-profile")
+    @GetMapping("/my-profile")
     public ResponseEntity<ResponseDTO<ProfileDetailResponseDTO>> getMyProfile(Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
         ProfileDetailResponseDTO responseDTO = userGrpcClient.getDetailProfile(memberId);
         ResponseDTO<ProfileDetailResponseDTO> result = new ResponseDTO<>(
                 responseDTO, HttpStatus.OK, "나의 프로필이 조회되었습니다."
         );
+        return ResponseEntity.ok(result);
+    }
+
+    // (마이페이지) 마케팅 동의 토글
+    @PostMapping("/my-profile/marketing")
+    public ResponseEntity<?> toggleAgreeMarketing(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        String message = userGrpcClient.toggleAgreeMarketing(memberId);
+        ResponseDTO<?> result = new ResponseDTO<>(null, HttpStatus.OK, message);
+        return ResponseEntity.ok(result);
+    }
+
+    // (마이페이지) 제3자 동의 토글
+    @PostMapping("/my-profile/third-party")
+    public ResponseEntity<?> toggleAgreeThirdParty(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        String message = userGrpcClient.toggleAgreeThirdParty(memberId);
+        ResponseDTO<?> result = new ResponseDTO<>(null, HttpStatus.OK, message);
         return ResponseEntity.ok(result);
     }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/UserController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/UserController.java
@@ -170,4 +170,15 @@ public class UserController {
         );
         return ResponseEntity.ok(result);
     }
+
+    // (마이페이지) 프로필 상세 조회
+    @GetMapping("my-profile")
+    public ResponseEntity<ResponseDTO<ProfileDetailResponseDTO>> getMyProfile(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        ProfileDetailResponseDTO responseDTO = userGrpcClient.getDetailProfile(memberId);
+        ResponseDTO<ProfileDetailResponseDTO> result = new ResponseDTO<>(
+                responseDTO, HttpStatus.OK, "나의 프로필이 조회되었습니다."
+        );
+        return ResponseEntity.ok(result);
+    }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/UserController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/UserController.java
@@ -160,7 +160,7 @@ public class UserController {
     }
 
     // 프로필 수정
-    @PutMapping("profile")
+    @PutMapping("my-profile")
     public ResponseEntity<ResponseDTO<ProfileResponseDTO>> updateProfile(Authentication authentication,
                                                                          @RequestBody UpdateProfileRequestDTO dto) {
         Long memberId = (Long) authentication.getPrincipal();

--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/UserController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/UserController.java
@@ -1,13 +1,7 @@
 package hanium.apigateway_service.controller;
 
-import hanium.apigateway_service.dto.user.request.LoginRequestDTO;
-import hanium.apigateway_service.dto.user.request.SignUpRequestDTO;
-import hanium.apigateway_service.dto.user.request.SmsRequestDTO;
-import hanium.apigateway_service.dto.user.request.VerifySmsRequestDTO;
-import hanium.apigateway_service.dto.user.response.MemberResponseDTO;
-import hanium.apigateway_service.dto.user.response.NaverConfigResponseDTO;
-import hanium.apigateway_service.dto.user.response.SignUpResponseDTO;
-import hanium.apigateway_service.dto.user.response.TokenResponseDTO;
+import hanium.apigateway_service.dto.user.request.*;
+import hanium.apigateway_service.dto.user.response.*;
 import hanium.apigateway_service.grpc.UserGrpcClient;
 import hanium.apigateway_service.response.ResponseDTO;
 import hanium.apigateway_service.security.JwtUtil;
@@ -21,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -148,6 +143,30 @@ public class UserController {
         TokenResponseDTO responseDTO = TokenResponseDTO.from(userGrpcClient.socialLogin(code, "naver"));
         ResponseDTO<TokenResponseDTO> result = new ResponseDTO<>(
                 responseDTO, HttpStatus.OK, "네이버 로그인에 성공했습니다."
+        );
+        return ResponseEntity.ok(result);
+    }
+
+    // 프로필사진 수정용 Presigned url 발급
+    @GetMapping("/presigned-url")
+    public ResponseEntity<ResponseDTO<PresignedUrlResponseDTO>> getPresignedUrl(Authentication authentication,
+                                                                                @RequestParam String contentType) {
+        Long memberId = (Long) authentication.getPrincipal();
+        PresignedUrlResponseDTO dto = userGrpcClient.getPresignedUrl(memberId, contentType);
+        ResponseDTO<PresignedUrlResponseDTO> result = new ResponseDTO<>(
+                dto, HttpStatus.OK, "Presigned URL이 발급되었습니다."
+        );
+        return ResponseEntity.ok(result);
+    }
+
+    // 프로필 수정
+    @PutMapping("profile")
+    public ResponseEntity<ResponseDTO<ProfileResponseDTO>> updateProfile(Authentication authentication,
+                                                                         @RequestBody UpdateProfileRequestDTO dto) {
+        Long memberId = (Long) authentication.getPrincipal();
+        ProfileResponseDTO responseDTO = userGrpcClient.updateProfile(memberId, dto);
+        ResponseDTO<ProfileResponseDTO> result = new ResponseDTO<>(
+                responseDTO, HttpStatus.OK, "프로필이 수정되었습니다."
         );
         return ResponseEntity.ok(result);
     }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/request/UpdateProfileRequestDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/request/UpdateProfileRequestDTO.java
@@ -1,0 +1,7 @@
+package hanium.apigateway_service.dto.user.request;
+
+public record UpdateProfileRequestDTO(
+        String nickname,
+        String imageUrl
+) {
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/PresignedUrlResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/PresignedUrlResponseDTO.java
@@ -1,0 +1,12 @@
+package hanium.apigateway_service.dto.user.response;
+
+import hanium.common.proto.user.PresignedUrlResponse;
+
+public record PresignedUrlResponseDTO(
+        String presignedUrl,
+        String actualImagePath
+) {
+    public static PresignedUrlResponseDTO from(PresignedUrlResponse protoResponse) {
+        return new PresignedUrlResponseDTO(protoResponse.getPresignedUrl(), protoResponse.getImagePath());
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/ProfileDetailResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/ProfileDetailResponseDTO.java
@@ -1,0 +1,29 @@
+package hanium.apigateway_service.dto.user.response;
+
+import hanium.common.proto.user.ProfileDetailResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProfileDetailResponseDTO(
+        Long memberId,
+        String nickname,
+        String imageUrl,
+        Long score,
+        List<String> mainCategory,
+        boolean agreeMarketing,
+        boolean agree3rdParty
+) {
+    public static ProfileDetailResponseDTO from(ProfileDetailResponse response) {
+        return ProfileDetailResponseDTO.builder()
+                .memberId(response.getMemberId())
+                .nickname(response.getNickname())
+                .imageUrl(response.getImageUrl())
+                .score(response.getScore())
+                .mainCategory(response.getMainCategoryList())
+                .agreeMarketing(response.getAgreeMarketing())
+                .agree3rdParty(response.getAgree3RdParty())
+                .build();
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/ProfileDetailResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/ProfileDetailResponseDTO.java
@@ -21,7 +21,7 @@ public record ProfileDetailResponseDTO(
                 .nickname(response.getNickname())
                 .imageUrl(response.getImageUrl())
                 .score(response.getScore())
-                .mainCategory(response.getMainCategoryList())
+                .mainCategory(response.getMainCategoryList().stream().toList())
                 .agreeMarketing(response.getAgreeMarketing())
                 .agree3rdParty(response.getAgree3RdParty())
                 .build();

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/ProfileResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/ProfileResponseDTO.java
@@ -1,0 +1,12 @@
+package hanium.apigateway_service.dto.user.response;
+
+import hanium.common.proto.user.ProfileResponse;
+
+public record ProfileResponseDTO(
+        String nickname,
+        String imageUrl
+) {
+    public static ProfileResponseDTO from(ProfileResponse res) {
+        return new ProfileResponseDTO(res.getNickname(), res.getProfileImg());
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/UserGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/UserGrpcClient.java
@@ -5,6 +5,7 @@ import hanium.apigateway_service.dto.user.request.SignUpRequestDTO;
 import hanium.apigateway_service.dto.user.request.UpdateProfileRequestDTO;
 import hanium.apigateway_service.dto.user.request.VerifySmsRequestDTO;
 import hanium.apigateway_service.dto.user.response.PresignedUrlResponseDTO;
+import hanium.apigateway_service.dto.user.response.ProfileDetailResponseDTO;
 import hanium.apigateway_service.dto.user.response.ProfileResponseDTO;
 import hanium.apigateway_service.mapper.UserGrpcMapperForGateway;
 import hanium.apigateway_service.security.JwtUtil;
@@ -150,6 +151,16 @@ public class UserGrpcClient {
         UpdateProfileRequest request = UserGrpcMapperForGateway.toUpdateProfileGrpc(memberId, dto);
         try {
             return ProfileResponseDTO.from(stub.updateProfile(request));
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
+
+    // 내 프로필 조회
+    public ProfileDetailResponseDTO getDetailProfile(Long memberId) {
+        GetProfileRequest request = GetProfileRequest.newBuilder().setMemberId(memberId).build();
+        try {
+            return ProfileDetailResponseDTO.from(stub.getDetailProfile(request));
         } catch (StatusRuntimeException e) {
             throw new CustomException(GrpcUtil.extractErrorCode(e));
         }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/UserGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/UserGrpcClient.java
@@ -2,7 +2,10 @@ package hanium.apigateway_service.grpc;
 
 import hanium.apigateway_service.dto.user.request.LoginRequestDTO;
 import hanium.apigateway_service.dto.user.request.SignUpRequestDTO;
+import hanium.apigateway_service.dto.user.request.UpdateProfileRequestDTO;
 import hanium.apigateway_service.dto.user.request.VerifySmsRequestDTO;
+import hanium.apigateway_service.dto.user.response.PresignedUrlResponseDTO;
+import hanium.apigateway_service.dto.user.response.ProfileResponseDTO;
 import hanium.apigateway_service.mapper.UserGrpcMapperForGateway;
 import hanium.apigateway_service.security.JwtUtil;
 import hanium.common.exception.CustomException;
@@ -126,6 +129,27 @@ public class UserGrpcClient {
                 .setCode(code).setProvider(provider).build();
         try {
             return stub.socialLogin(request);
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
+
+    // 프로필사진 수정용 Presigned url 발급
+    public PresignedUrlResponseDTO getPresignedUrl(Long memberId, String contentType) {
+        GetPresignedUrlRequest request = GetPresignedUrlRequest.newBuilder()
+                .setMemberId(memberId).setContentType(contentType).build();
+        try {
+            return PresignedUrlResponseDTO.from(stub.getPresignedUrl(request));
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
+
+    // 프로필 수정
+    public ProfileResponseDTO updateProfile(Long memberId, UpdateProfileRequestDTO dto) {
+        UpdateProfileRequest request = UserGrpcMapperForGateway.toUpdateProfileGrpc(memberId, dto);
+        try {
+            return ProfileResponseDTO.from(stub.updateProfile(request));
         } catch (StatusRuntimeException e) {
             throw new CustomException(GrpcUtil.extractErrorCode(e));
         }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/UserGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/UserGrpcClient.java
@@ -165,4 +165,24 @@ public class UserGrpcClient {
             throw new CustomException(GrpcUtil.extractErrorCode(e));
         }
     }
+
+    // 마이페이지 마케팅 동의 토글
+    public String toggleAgreeMarketing(Long memberId) {
+        GetProfileRequest request = GetProfileRequest.newBuilder().setMemberId(memberId).build();
+        try {
+            return stub.toggleMarketing(request).getMessage();
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
+
+    // 마이페이지 제3자 동의 토글
+    public String toggleAgreeThirdParty(Long memberId) {
+        GetProfileRequest request = GetProfileRequest.newBuilder().setMemberId(memberId).build();
+        try {
+            return stub.toggleThirdParty(request).getMessage();
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/mapper/UserGrpcMapperForGateway.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/mapper/UserGrpcMapperForGateway.java
@@ -2,9 +2,11 @@ package hanium.apigateway_service.mapper;
 
 import hanium.apigateway_service.dto.user.request.LoginRequestDTO;
 import hanium.apigateway_service.dto.user.request.SignUpRequestDTO;
+import hanium.apigateway_service.dto.user.request.UpdateProfileRequestDTO;
 import hanium.apigateway_service.dto.user.request.VerifySmsRequestDTO;
 import hanium.common.proto.user.LoginRequest;
 import hanium.common.proto.user.SignUpRequest;
+import hanium.common.proto.user.UpdateProfileRequest;
 import hanium.common.proto.user.VerifySmsRequest;
 
 public class UserGrpcMapperForGateway {
@@ -35,6 +37,14 @@ public class UserGrpcMapperForGateway {
         return VerifySmsRequest.newBuilder()
                 .setPhoneNumber(dto.getPhoneNumber())
                 .setSmsCode(dto.getSmsCode())
+                .build();
+    }
+
+    public static UpdateProfileRequest toUpdateProfileGrpc(Long memberId, UpdateProfileRequestDTO dto) {
+        return UpdateProfileRequest.newBuilder()
+                .setMemberId(memberId)
+                .setNickname(dto.nickname())
+                .setImageUrl(dto.imageUrl())
                 .build();
     }
 }

--- a/common/src/main/java/hanium/common/exception/ErrorCode.java
+++ b/common/src/main/java/hanium/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(404, "해당하는 Member를 찾을 수 없습니다."),
     AUTHORITY_NOT_FOUND(404, "사용자의 권한을 조회할 수 없습니다."),
     REFRESH_NOT_FOUND(404, "데이터베이스에서 Refresh 토큰을 찾을 수 없습니다."),
+    INVALID_PROFILE_IMAGE_TYPE(400, "프로필 사진은 image 형식만 등록할 수 있습니다."),
 
     // -- PRODUCT-SERVICE -- //
     ERROR_ADD_PRODUCT(500, "상품 등록 중 문제가 발생했습니다."),

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -59,6 +59,8 @@ service ProductService {
   rpc CreateChatroom(CreateChatroomRequest) returns (CreateChatroomResponse);
   rpc GetMyChatrooms(ListMyChatroomsRequest)returns (ListMyChatroomsResponse);
 
+  // 10. User-service서 주요 활동 카테고리 조회
+  rpc GetMainCategory(ProductMainRequest) returns (GetMainCategoryResponse);
 }
 
 message Empty {}
@@ -232,12 +234,12 @@ enum MessageType{
   IMAGE = 1;
   DIRECT_REQUEST = 3;
   DIRECT_ACCEPT = 4;
-  PARCEL_REQUEST= 5;
-  PARCEL_ACCEPT= 6;
-  PAYMENT_REQUEST=7;
-  PAYMENT_DONE=8;
-  ADDRESS_REGISTER=9;
-  ADDRESS_REGISTER_DONE=10;
+  PARCEL_REQUEST = 5;
+  PARCEL_ACCEPT = 6;
+  PAYMENT_REQUEST = 7;
+  PAYMENT_DONE = 8;
+  ADDRESS_REGISTER = 9;
+  ADDRESS_REGISTER_DONE = 10;
 }
 message PresignedUrl {
   string putUrl = 1;
@@ -284,10 +286,15 @@ message ChatroomSummary{
   int64 productId = 4;
   int64 opponentId = 5; //상대방 아이디
   int64 latestTime = 6;
-  string opponentProfileUrl =7;
-  string opponentNickname =8;
+  string opponentProfileUrl = 7;
+  string opponentNickname = 8;
 
 }
 message ListMyChatroomsResponse {
   repeated ChatroomSummary items = 1;
+}
+
+// 주요 활동 카테고리 조회
+message GetMainCategoryResponse {
+  repeated string category = 1;
 }

--- a/common/src/main/proto/user.proto
+++ b/common/src/main/proto/user.proto
@@ -50,6 +50,10 @@ service UserService {
 
   // 13. 프로필 상세 조회
   rpc GetDetailProfile(GetProfileRequest) returns (ProfileDetailResponse);
+
+  // 14. 마케팅/제3자 동의 토글
+  rpc ToggleMarketing(GetProfileRequest) returns (SendSmsResponse);
+  rpc ToggleThirdParty(GetProfileRequest) returns (SendSmsResponse);
 }
 
 // 1. 회원가입

--- a/common/src/main/proto/user.proto
+++ b/common/src/main/proto/user.proto
@@ -41,6 +41,12 @@ service UserService {
 
   // 10. 프로필 조회
   rpc GetProfile(GetProfileRequest) returns (ProfileResponse);
+
+  // 11. (프로필 업로드용) s3 presigned url 발급
+  rpc GetPresignedUrl(GetPresignedUrlRequest) returns (PresignedUrlResponse);
+
+  // 12. 프로필 업데이트
+  rpc UpdateProfile(UpdateProfileRequest) returns (ProfileResponse);
 }
 
 // 1. 회원가입
@@ -148,4 +154,21 @@ message GetProfileRequest {
 message ProfileResponse {
   string nickname = 1;
   string profile_img = 2;
+}
+
+// 11. (프로필 업로드용) s3 presigned url 발급
+message GetPresignedUrlRequest {
+  int64 member_id = 1;
+  string content_type = 2;
+}
+message PresignedUrlResponse {
+  string presigned_url = 1;
+  string image_path = 2;
+}
+
+// 12. 프로필 수정
+message UpdateProfileRequest {
+  int64 member_id = 1;
+  string nickname = 2;
+  string image_url = 3;
 }

--- a/common/src/main/proto/user.proto
+++ b/common/src/main/proto/user.proto
@@ -47,6 +47,9 @@ service UserService {
 
   // 12. 프로필 업데이트
   rpc UpdateProfile(UpdateProfileRequest) returns (ProfileResponse);
+
+  // 13. 프로필 상세 조회
+  rpc GetDetailProfile(GetProfileRequest) returns (ProfileDetailResponse);
 }
 
 // 1. 회원가입
@@ -154,6 +157,15 @@ message GetProfileRequest {
 message ProfileResponse {
   string nickname = 1;
   string profile_img = 2;
+}
+message ProfileDetailResponse {
+  int64 member_id = 1;
+  string nickname = 2;
+  string image_url = 3;
+  int64 score = 4;
+  repeated string main_category = 5;
+  bool agreeMarketing = 6;
+  bool agree3rdParty = 7;
 }
 
 // 11. (프로필 업로드용) s3 presigned url 발급

--- a/product-service/src/main/java/hanium/product_service/domain/Product.java
+++ b/product-service/src/main/java/hanium/product_service/domain/Product.java
@@ -32,7 +32,7 @@ public class Product extends BaseEntity {
     @Column
     private Long price;
 
-    @Column
+    @Column(name = "seller_id")
     private Long sellerId;
 
     @Enumerated(EnumType.STRING)

--- a/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
@@ -30,6 +30,7 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
     private final ProductLikeService likeService;
     private final ProductReportService reportService;
     private final ProductSearchService productSearchService;
+    private final ProductUserService productUserService;
     private final ChatService chatService;
     private final PresignService presign;
     private final ProfileGrpcClient profileGrpcClient;
@@ -313,5 +314,17 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
 
         responseObserver.onNext(resp.build());
         responseObserver.onCompleted();
+    }
+
+    // 프로필 > 주요 활동 카테고리 조회
+    @Override
+    public void getMainCategory(ProductMainRequest request, StreamObserver<GetMainCategoryResponse> responseObserver) {
+        try {
+            List<String> result = productUserService.getMainCategoryByMemberId(request.getMemberId());
+            responseObserver.onNext(GetMainCategoryResponse.newBuilder().addAllCategory(result).build());
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
     }
 }

--- a/product-service/src/main/java/hanium/product_service/grpc/ProfileGrpcClient.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ProfileGrpcClient.java
@@ -2,12 +2,9 @@ package hanium.product_service.grpc;
 
 import hanium.common.exception.CustomException;
 import hanium.common.exception.GrpcUtil;
-import hanium.common.proto.user.GetNicknameRequest;
-import hanium.common.proto.user.GetNicknameResponse;
 import hanium.common.proto.user.GetProfileRequest;
 import hanium.common.proto.user.UserServiceGrpc;
 import hanium.product_service.dto.response.ProfileResponseDTO;
-import hanium.product_service.mapper.ProfileGrpcMapper;
 import io.grpc.StatusRuntimeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/product-service/src/main/java/hanium/product_service/service/ProductUserService.java
+++ b/product-service/src/main/java/hanium/product_service/service/ProductUserService.java
@@ -1,0 +1,14 @@
+package hanium.product_service.service;
+
+import hanium.product_service.dto.response.SimpleProductDTO;
+
+import java.util.List;
+
+public interface ProductUserService {
+
+    List<String> getMainCategoryByMemberId(Long memberId);
+
+    List<SimpleProductDTO> getMySellingProducts(Long memberId);
+
+    List<SimpleProductDTO> getMyBuyingProducts(Long memberId);
+}

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductUserServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductUserServiceImpl.java
@@ -1,0 +1,53 @@
+package hanium.product_service.service.impl;
+
+import hanium.product_service.domain.Category;
+import hanium.product_service.dto.response.SimpleProductDTO;
+import hanium.product_service.repository.ProductRepository;
+import hanium.product_service.service.ProductUserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ProductUserServiceImpl implements ProductUserService {
+
+    private final ProductRepository productRepository;
+
+    // memberId별 판매 상품 기반한 주요 활동 카테고리 최대 2개 반환
+    @Override
+    public List<String> getMainCategoryByMemberId(Long memberId) {
+        Pageable pageable = PageRequest.of(0, 100);
+        Page<Category> productList = productRepository.findProductBySellerId(memberId, pageable);
+        List<String> result = new ArrayList<>();
+        for (Category item : productList) {
+            String label = item.getLabel();
+            if (!result.contains(label)) {
+                result.add(label);
+            }
+            if (result.size() == 2) {
+                return result;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public List<SimpleProductDTO> getMySellingProducts(Long memberId) {
+        return List.of();
+    }
+
+    @Override
+    public List<SimpleProductDTO> getMyBuyingProducts(Long memberId) {
+        return List.of();
+    }
+}

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -134,6 +134,9 @@ dependencies {
     // WebClient (Spring WebFlux)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // AWS S3
+    implementation "software.amazon.awssdk:s3:2.17.217"
+
     //prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/user-service/src/main/java/hanium/user_service/config/AwsConfig.java
+++ b/user-service/src/main/java/hanium/user_service/config/AwsConfig.java
@@ -1,0 +1,42 @@
+package hanium.user_service.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${spring.cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Getter
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Getter
+    @Value("${spring.cloud.aws.s3.domain}")
+    private String domain;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsCredentialsProvider credentialsProvider =
+                StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+}

--- a/user-service/src/main/java/hanium/user_service/domain/Member.java
+++ b/user-service/src/main/java/hanium/user_service/domain/Member.java
@@ -2,6 +2,7 @@ package hanium.user_service.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,34 +13,45 @@ import java.util.Collection;
 
 @Entity
 @Getter
-@Setter
 @Builder
-@Table(name = "MEMBER")
-@NoArgsConstructor
-@AllArgsConstructor
+@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@DynamicUpdate
 public class Member extends BaseEntity implements UserDetails {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column
+
+    @Column(unique = true, nullable = false, updatable = false)
     private String email;
+
     @Column
     private String password;
-    @Column
+
+    @Column(unique = true, length = 11)
     private String phoneNumber;
 
     @Enumerated(value = EnumType.STRING)
     private Provider provider;
-    @Column
-    private String providerUserId;
 
     @Enumerated(value = EnumType.STRING)
     private Role role;
 
     @Column
     private boolean isAgreeMarketing;
+
     @Column
     private boolean isAgreeThirdParty;
+
+    public void updateMarketingStatus(boolean isAgreeMarketing) {
+        this.isAgreeMarketing = isAgreeMarketing;
+    }
+
+    public void updateThirdPartyStatus(boolean isAgreeThirdParty) {
+        this.isAgreeThirdParty = isAgreeThirdParty;
+    }
 
     // UserDetails 메서드 구현
     @Override

--- a/user-service/src/main/java/hanium/user_service/domain/Profile.java
+++ b/user-service/src/main/java/hanium/user_service/domain/Profile.java
@@ -6,6 +6,9 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -31,6 +34,12 @@ public class Profile extends BaseEntity {
     @Column
     private Long score;
 
+    @ElementCollection(fetch = FetchType.LAZY)
+    List<String> mainCategory;
+
+    @Column(name = "main_category_ttl")
+    LocalDateTime mainCategoryTTL;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;
@@ -38,5 +47,10 @@ public class Profile extends BaseEntity {
     public void update(String nickname, String imageUrl) {
         this.nickname = nickname;
         this.imageUrl = imageUrl;
+    }
+
+    public void updateMainCategory(List<String> mainCategory, LocalDateTime mainCategoryTTL) {
+        this.mainCategory = mainCategory;
+        this.mainCategoryTTL = mainCategoryTTL;
     }
 }

--- a/user-service/src/main/java/hanium/user_service/domain/Profile.java
+++ b/user-service/src/main/java/hanium/user_service/domain/Profile.java
@@ -2,14 +2,17 @@ package hanium.user_service.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
-@Setter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@DynamicUpdate
 @Table(name = "PROFILE")
 // 삭제 시, 삭제 일시를 업데이트하는 쿼리 날림
 @SQLDelete(sql = "UPDATE PROFILE SET PROFILE.DELETED_AT = CURRENT_TIMESTAMP WHERE PROFILE.ID = ?")
@@ -28,4 +31,9 @@ public class Profile extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;
+
+    public void update(String nickname, String imageUrl) {
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/user-service/src/main/java/hanium/user_service/domain/Profile.java
+++ b/user-service/src/main/java/hanium/user_service/domain/Profile.java
@@ -28,6 +28,9 @@ public class Profile extends BaseEntity {
     @Column
     private String imageUrl;
 
+    @Column
+    private Long score;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;

--- a/user-service/src/main/java/hanium/user_service/dto/request/GetPresignedUrlRequestDTO.java
+++ b/user-service/src/main/java/hanium/user_service/dto/request/GetPresignedUrlRequestDTO.java
@@ -1,0 +1,14 @@
+package hanium.user_service.dto.request;
+
+import hanium.common.proto.user.GetPresignedUrlRequest;
+import lombok.Builder;
+
+@Builder
+public record GetPresignedUrlRequestDTO(
+        Long memberId,
+        String contentType
+) {
+    public static GetPresignedUrlRequestDTO from(GetPresignedUrlRequest request) {
+        return new GetPresignedUrlRequestDTO(request.getMemberId(), request.getContentType());
+    }
+}

--- a/user-service/src/main/java/hanium/user_service/dto/response/PresignedUrlResponseDTO.java
+++ b/user-service/src/main/java/hanium/user_service/dto/response/PresignedUrlResponseDTO.java
@@ -1,0 +1,10 @@
+package hanium.user_service.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record PresignedUrlResponseDTO(
+        String presignedUrl,
+        String actualImagePath
+) {
+}

--- a/user-service/src/main/java/hanium/user_service/dto/response/ProfileDetailResponseDTO.java
+++ b/user-service/src/main/java/hanium/user_service/dto/response/ProfileDetailResponseDTO.java
@@ -1,0 +1,17 @@
+package hanium.user_service.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProfileDetailResponseDTO(
+        Long memberId,
+        String nickname,
+        String imageUrl,
+        Long score,
+        List<String> mainCategory,
+        boolean agreeMarketing,
+        boolean agree3rdParty
+) {
+}

--- a/user-service/src/main/java/hanium/user_service/grpc/ProductUserGrpcClient.java
+++ b/user-service/src/main/java/hanium/user_service/grpc/ProductUserGrpcClient.java
@@ -1,0 +1,32 @@
+package hanium.user_service.grpc;
+
+import hanium.common.exception.CustomException;
+import hanium.common.exception.GrpcUtil;
+import hanium.common.proto.product.ProductMainRequest;
+import hanium.common.proto.product.ProductServiceGrpc;
+import io.grpc.StatusRuntimeException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProductUserGrpcClient {
+
+    @GrpcClient("product-service")
+    private ProductServiceGrpc.ProductServiceBlockingStub stub;
+
+    // 프로필 > 주요 활동 카테고리 조회
+    public List<String> getMainCategories(Long memberId) {
+        try {
+            ProductMainRequest request = ProductMainRequest.newBuilder().setMemberId(memberId).build();
+            return stub.getMainCategory(request).getCategoryList().stream().toList();
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
+}

--- a/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
+++ b/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
@@ -235,4 +235,28 @@ public class UserGrpcService extends UserServiceGrpc.UserServiceImplBase {
             responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
         }
     }
+
+    // 마이페이지 마케팅 동의 토글
+    @Override
+    public void toggleMarketing(GetProfileRequest request, StreamObserver<SendSmsResponse> responseObserver) {
+        try {
+            String message = memberService.toggleAgreeMarketing(request.getMemberId());
+            responseObserver.onNext(SendSmsResponse.newBuilder().setMessage(message).build());
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
+
+    // 마이페이지 제3자 동의 토글
+    @Override
+    public void toggleThirdParty(GetProfileRequest request, StreamObserver<SendSmsResponse> responseObserver) {
+        try {
+            String message = memberService.toggleAgreeThirdParty(request.getMemberId());
+            responseObserver.onNext(SendSmsResponse.newBuilder().setMessage(message).build());
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
 }

--- a/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
+++ b/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
@@ -6,10 +6,7 @@ import hanium.common.exception.GrpcUtil;
 import hanium.common.proto.common.Empty;
 import hanium.common.proto.user.*;
 import hanium.user_service.domain.Member;
-import hanium.user_service.dto.request.GetNicknameRequestDTO;
-import hanium.user_service.dto.request.LoginRequestDTO;
-import hanium.user_service.dto.request.SignUpRequestDTO;
-import hanium.user_service.dto.request.VerifySmsDTO;
+import hanium.user_service.dto.request.*;
 import hanium.user_service.dto.response.*;
 import hanium.user_service.mapper.MemberGrpcMapper;
 import hanium.user_service.service.*;
@@ -196,6 +193,30 @@ public class UserGrpcService extends UserServiceGrpc.UserServiceImplBase {
                             profileService.getProfileByMemberId(request.getMemberId())
                     )
             );
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
+
+    // 프로필사진 수정용 presigned url
+    @Override
+    public void getPresignedUrl(GetPresignedUrlRequest request, StreamObserver<PresignedUrlResponse> responseObserver) {
+        try {
+            PresignedUrlResponseDTO dto =
+                    profileService.getPresignedUrl(GetPresignedUrlRequestDTO.from(request));
+            responseObserver.onNext(MemberGrpcMapper.toPresignedUrlResponse(dto));
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
+
+    @Override
+    public void updateProfile(UpdateProfileRequest request, StreamObserver<ProfileResponse> responseObserver) {
+        try {
+            ProfileResponseDTO dto = profileService.updateProfile(request);
+            responseObserver.onNext(MemberGrpcMapper.toProfileResponse(dto));
             responseObserver.onCompleted();
         } catch (CustomException e) {
             responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));

--- a/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
+++ b/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
@@ -212,11 +212,24 @@ public class UserGrpcService extends UserServiceGrpc.UserServiceImplBase {
         }
     }
 
+    // 프로필 수정
     @Override
     public void updateProfile(UpdateProfileRequest request, StreamObserver<ProfileResponse> responseObserver) {
         try {
             ProfileResponseDTO dto = profileService.updateProfile(request);
             responseObserver.onNext(MemberGrpcMapper.toProfileResponse(dto));
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
+
+    // 프로필 상세 조회
+    @Override
+    public void getDetailProfile(GetProfileRequest request, StreamObserver<ProfileDetailResponse> responseObserver) {
+        try {
+            ProfileDetailResponseDTO dto = profileService.getProfileDetailByMemberId(request.getMemberId());
+            responseObserver.onNext(MemberGrpcMapper.toProfileDetailResponse(dto));
             responseObserver.onCompleted();
         } catch (CustomException e) {
             responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));

--- a/user-service/src/main/java/hanium/user_service/mapper/MemberGrpcMapper.java
+++ b/user-service/src/main/java/hanium/user_service/mapper/MemberGrpcMapper.java
@@ -79,4 +79,17 @@ public class MemberGrpcMapper {
                 .setImagePath(dto.actualImagePath())
                 .build();
     }
+
+    // 프로필 상세 조회
+    public static ProfileDetailResponse toProfileDetailResponse(ProfileDetailResponseDTO dto) {
+        return ProfileDetailResponse.newBuilder()
+                .setMemberId(dto.memberId())
+                .setNickname(dto.nickname())
+                .setImageUrl(dto.imageUrl())
+                .setScore(dto.score())
+                .addAllMainCategory(dto.mainCategory())
+                .setAgreeMarketing(dto.agreeMarketing())
+                .setAgree3RdParty(dto.agree3rdParty())
+                .build();
+    }
 }

--- a/user-service/src/main/java/hanium/user_service/mapper/MemberGrpcMapper.java
+++ b/user-service/src/main/java/hanium/user_service/mapper/MemberGrpcMapper.java
@@ -71,4 +71,12 @@ public class MemberGrpcMapper {
                 .setProfileImg(dto.getProfileImg())
                 .build();
     }
+
+    // 프로필사진 변경용 presigned url 응답
+    public static PresignedUrlResponse toPresignedUrlResponse(PresignedUrlResponseDTO dto) {
+        return PresignedUrlResponse.newBuilder()
+                .setPresignedUrl(dto.presignedUrl())
+                .setImagePath(dto.actualImagePath())
+                .build();
+    }
 }

--- a/user-service/src/main/java/hanium/user_service/service/MemberService.java
+++ b/user-service/src/main/java/hanium/user_service/service/MemberService.java
@@ -5,7 +5,11 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface MemberService extends UserDetailsService {
 
-    public Member getMemberById(Long memberId);
+    Member getMemberById(Long memberId);
 
-    public Member getMemberByEmail(String email);
+    Member getMemberByEmail(String email);
+
+    String toggleAgreeMarketing(Long memberId);
+
+    String toggleAgreeThirdParty(Long memberId);
 }

--- a/user-service/src/main/java/hanium/user_service/service/ProfileService.java
+++ b/user-service/src/main/java/hanium/user_service/service/ProfileService.java
@@ -1,11 +1,19 @@
 package hanium.user_service.service;
 
+import hanium.common.proto.user.UpdateProfileRequest;
 import hanium.user_service.dto.request.GetNicknameRequestDTO;
+import hanium.user_service.dto.request.GetPresignedUrlRequestDTO;
 import hanium.user_service.dto.response.GetNicknameResponseDTO;
+import hanium.user_service.dto.response.PresignedUrlResponseDTO;
 import hanium.user_service.dto.response.ProfileResponseDTO;
 
 public interface ProfileService {
+
     GetNicknameResponseDTO getNicknameByMemberId(GetNicknameRequestDTO requestDTO);
 
     ProfileResponseDTO getProfileByMemberId(Long memberId);
+
+    PresignedUrlResponseDTO getPresignedUrl(GetPresignedUrlRequestDTO dto);
+
+    ProfileResponseDTO updateProfile(UpdateProfileRequest request);
 }

--- a/user-service/src/main/java/hanium/user_service/service/ProfileService.java
+++ b/user-service/src/main/java/hanium/user_service/service/ProfileService.java
@@ -5,6 +5,7 @@ import hanium.user_service.dto.request.GetNicknameRequestDTO;
 import hanium.user_service.dto.request.GetPresignedUrlRequestDTO;
 import hanium.user_service.dto.response.GetNicknameResponseDTO;
 import hanium.user_service.dto.response.PresignedUrlResponseDTO;
+import hanium.user_service.dto.response.ProfileDetailResponseDTO;
 import hanium.user_service.dto.response.ProfileResponseDTO;
 
 public interface ProfileService {
@@ -16,4 +17,6 @@ public interface ProfileService {
     PresignedUrlResponseDTO getPresignedUrl(GetPresignedUrlRequestDTO dto);
 
     ProfileResponseDTO updateProfile(UpdateProfileRequest request);
+
+    ProfileDetailResponseDTO getProfileDetailByMemberId(Long memberId);
 }

--- a/user-service/src/main/java/hanium/user_service/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/AuthServiceImpl.java
@@ -54,14 +54,14 @@ public class AuthServiceImpl implements AuthService {
             Profile profile = Profile.builder()
                     .nickname(dto.getNickname())
                     .imageUrl(imageUrl)
-                    .member(member).build();
+                    .score(20L)
+                    .member(member)
+                    .build();
 
             memberRepository.save(member);
             profileRepository.save(profile);
 
-            log.info("✅ Member added: {}", member.getEmail());
-            log.info("✅ Profile added, id: {} for Member id: {}", profile.getId(), member.getId());
-            log.info("✅ Member authorities: {}", member.getAuthorities());
+            log.info("✅ [회원가입 완료] Profile id={} for Member id={}", profile.getId(), member.getId());
 
             return member;
         }

--- a/user-service/src/main/java/hanium/user_service/service/impl/MemberServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/MemberServiceImpl.java
@@ -42,4 +42,30 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
+
+    // 마이페이지 마케팅 동의 토글
+    @Override
+    public String toggleAgreeMarketing(Long memberId) {
+        Member member = getMemberById(memberId);
+        if (member.isAgreeMarketing()) {
+            member.updateMarketingStatus(false);
+            return "마케팅 정보 수신 동의를 해제하였습니다.";
+        } else {
+            member.updateMarketingStatus(true);
+            return "마케팅 정보 수신에 동의하였습니다.";
+        }
+    }
+
+    // 마이페이지 제3자 동의 토글
+    @Override
+    public String toggleAgreeThirdParty(Long memberId) {
+        Member member = getMemberById(memberId);
+        if (member.isAgreeThirdParty()) {
+            member.updateThirdPartyStatus(false);
+            return "개인정보 제3자 제공 동의를 해제하였습니다.";
+        } else {
+            member.updateThirdPartyStatus(true);
+            return "개인정보 제3자 제공에 동의하였습니다.";
+        }
+    }
 }

--- a/user-service/src/main/java/hanium/user_service/service/impl/ProfileServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/ProfileServiceImpl.java
@@ -3,11 +3,13 @@ package hanium.user_service.service.impl;
 import hanium.common.exception.CustomException;
 import hanium.common.exception.ErrorCode;
 import hanium.common.proto.user.UpdateProfileRequest;
+import hanium.user_service.domain.Member;
 import hanium.user_service.domain.Profile;
 import hanium.user_service.dto.request.GetNicknameRequestDTO;
 import hanium.user_service.dto.request.GetPresignedUrlRequestDTO;
 import hanium.user_service.dto.response.GetNicknameResponseDTO;
 import hanium.user_service.dto.response.PresignedUrlResponseDTO;
+import hanium.user_service.dto.response.ProfileDetailResponseDTO;
 import hanium.user_service.dto.response.ProfileResponseDTO;
 import hanium.user_service.repository.ProfileRepository;
 import hanium.user_service.service.ProfileService;
@@ -16,6 +18,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -60,5 +65,26 @@ public class ProfileServiceImpl implements ProfileService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         profile.update(request.getNickname(), request.getImageUrl());
         return ProfileResponseDTO.from(profile);
+    }
+
+    // 마이페이지 정보 조회
+    @Override
+    public ProfileDetailResponseDTO getProfileDetailByMemberId(Long memberId) {
+        Profile profile = profileRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = profile.getMember();
+
+        // todo: 주요 활동 카테고리 로직 추가
+        List<String> mainCategory = new ArrayList<>();
+
+        return ProfileDetailResponseDTO.builder()
+                .memberId(memberId)
+                .nickname(profile.getNickname())
+                .imageUrl(profile.getImageUrl())
+                .score(profile.getScore())
+                .mainCategory(mainCategory)
+                .agreeMarketing(member.isAgreeMarketing())
+                .agree3rdParty(member.isAgreeThirdParty())
+                .build();
     }
 }

--- a/user-service/src/main/java/hanium/user_service/util/S3Util.java
+++ b/user-service/src/main/java/hanium/user_service/util/S3Util.java
@@ -1,0 +1,70 @@
+package hanium.user_service.util;
+
+import hanium.common.exception.CustomException;
+import hanium.common.exception.ErrorCode;
+import hanium.user_service.config.AwsConfig;
+import hanium.user_service.dto.request.GetPresignedUrlRequestDTO;
+import hanium.user_service.dto.response.PresignedUrlResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3Util {
+
+    private static final Duration PRESIGNED_URL_EXPIRATION = Duration.ofMinutes(3);
+
+    private final S3Presigner s3Presigner;
+    private final AwsConfig awsConfig;
+
+    public PresignedUrlResponseDTO getPresignedUrl(GetPresignedUrlRequestDTO dto) {
+        if (dto.contentType().isBlank() || !dto.contentType().startsWith("image/")) {
+            throw new CustomException(ErrorCode.INVALID_PROFILE_IMAGE_TYPE);
+        }
+
+        String imageKey = generateImageKey(dto.memberId()) + extension(dto.contentType());
+        PutObjectPresignRequest presignRequest = buildPresignedRequest(imageKey);
+
+        // presigned url
+        String presignedUrl = s3Presigner.presignPutObject(presignRequest).url().toString();
+        // 실제 조회에 사용되는 url
+        String actualImagePath = awsConfig.getDomain() + imageKey;
+
+        return PresignedUrlResponseDTO.builder()
+                .presignedUrl(presignedUrl)
+                .actualImagePath(actualImagePath)
+                .build();
+    }
+
+    // 이미지 키 생성
+    private String generateImageKey(Long memberId) {
+        return memberId.toString() + "/" + UUID.randomUUID();
+    }
+
+    // presigned url 요청 생성
+    private PutObjectPresignRequest buildPresignedRequest(String key) {
+        PutObjectRequest.Builder requestBuilder = PutObjectRequest.builder()
+                .bucket(awsConfig.getBucket())
+                .key("profile_image/" + key);
+        return PutObjectPresignRequest.builder()
+                .signatureDuration(PRESIGNED_URL_EXPIRATION)
+                .putObjectRequest(requestBuilder.build())
+                .build();
+    }
+
+    private String extension(String contentType) {
+        return switch (contentType) {
+            case "image/jpeg" -> ".jpg";
+            case "image/png" -> ".png";
+            case "image/webp" -> ".webp";
+            case "image/gif" -> ".gif";
+            default -> ".bin";
+        };
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈
<!-- 관련된 이슈를 연결해주세요 -->
Closes #79

## 💼 작업 설명
<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->
마이페이지의 프로필 관련 기능을 구현했습니다.
1. 내 프로필 조회 (닉네임, 프로필사진, 신뢰도점수, 주요 활동 카테고리 등) 
2. 내 프로필 수정 (프로필사진 및 닉네임 수정) 
3. 마케팅/제3자 동의항목 토글 

## ✅ 구현/변경사항
<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
_**user-service-test 설정파일 업데이트 필요합니다.**_
- Profile 엔티티 내부에 주요 활동 카테고리, 신뢰도점수 관련 필드 추가 
- 유저서비스->상품서비스 통신용으로 grpc 메서드 및 yml 설정 추가 
- s3에 프로필사진 업로드용으로 유저서비스 yml에 aws 관련 설정 추가 

## 📝 리뷰 요구사항
<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->
