### PR TITLE
[test/#84] 상품 검색 및 거래 평가 테스트 코드 작성

### DIFF
--- a/product-service/src/test/java/hanium/product_service/service/impl/ProductSearchServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/ProductSearchServiceImplTest.java
@@ -1,0 +1,110 @@
+package hanium.product_service.service.impl;
+
+import hanium.product_service.dto.request.ProductSearchRequestDTO;
+import hanium.product_service.dto.response.ProductSearchResponseDTO;
+import hanium.product_service.dto.response.SimpleProductDTO;
+import hanium.product_service.elasticsearch.ProductDocument;
+import hanium.product_service.elasticsearch.ProductSearchElasticRepository;
+import hanium.product_service.repository.ProductRepository;
+import hanium.product_service.repository.projection.ProductWithFirstImage;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+
+@ActiveProfiles("test")
+@DisplayName("상품 검색 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class ProductSearchServiceImplTest {
+
+    @Mock
+    private ProductSearchElasticRepository productSearchElasticRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductSearchServiceImpl sut;
+
+    @Test
+    @DisplayName("상품을 키워드로 검색하고 최신순으로 정렬한다")
+    void searchProductReadOnly_SortByRecent() {
+        // given
+        ProductSearchRequestDTO req = new ProductSearchRequestDTO(1L, "유모차", "recent", 0);
+        Pageable pageable = PageRequest.of(req.getPage(), 20);
+
+        ProductDocument doc1 = ProductDocument.builder().id(1L).title("유모차").build();
+        ProductDocument doc2 = ProductDocument.builder().id(2L).title("유아 영어책").build();
+        given(productSearchElasticRepository.findByTitle(req.getKeyword())).willReturn(List.of(doc1, doc2));
+
+        List<Long> ids = List.of(1L, 2L);
+        ProductWithFirstImage p1 = stubProduct(1L, "유모차", 100000L, "image_url");
+        ProductWithFirstImage p2 = stubProduct(2L, "유아 영어책", 150000L, null);
+        given(productRepository.findProductByIdsAndSortByRecent(ids, pageable)).willReturn(List.of(p1, p2));
+
+        // when
+        ProductSearchResponseDTO result = sut.searchProductReadOnly(req);
+
+        // then
+        assertThat(result.getProductList()).hasSize(2);
+        SimpleProductDTO resultDto1 = result.getProductList().getFirst();
+        assertThat(resultDto1.getProductId()).isEqualTo(1L);
+        assertThat(resultDto1.getTitle()).isEqualTo("유모차");
+        assertThat(resultDto1.getImageUrl()).isEqualTo("image_url");
+
+        SimpleProductDTO resultDto2 = result.getProductList().get(1);
+        assertThat(resultDto2.getProductId()).isEqualTo(2L);
+        assertThat(resultDto2.getImageUrl()).isEqualTo("");
+
+        then(productSearchElasticRepository).should().findByTitle(req.getKeyword());
+        then(productRepository).should().findProductByIdsAndSortByRecent(ids, pageable);
+    }
+
+    @Test
+    @DisplayName("상품을 키워드로 검색하고 인기순으로 정렬한다")
+    void searchProductReadOnly_SortByLike() {
+        // given
+        ProductSearchRequestDTO req = new ProductSearchRequestDTO(1L, "의자", "like", 0);
+        Pageable pageable = PageRequest.of(req.getPage(), 20);
+        List<Long> ids = List.of(3L, 4L);
+
+        ProductDocument doc1 = ProductDocument.builder().id(3L).title("유아 의자").build();
+        ProductDocument doc2 = ProductDocument.builder().id(4L).title("유아용 의자").build();
+        given(productSearchElasticRepository.findByTitle(req.getKeyword())).willReturn(List.of(doc1, doc2));
+
+        ProductWithFirstImage p1 = stubProduct(3L, "유아 의자", 80000L, "image_url");
+        ProductWithFirstImage p2 = stubProduct(4L, "유아용 의자", 200000L, "image_url");
+        given(productRepository.findProductByIdsAndSortByLike(ids, pageable)).willReturn(List.of(p1, p2));
+
+        // when
+        ProductSearchResponseDTO result = sut.searchProductReadOnly(req);
+
+        // then
+        assertThat(result.getProductList()).hasSize(2);
+        assertThat(result.getProductList().getFirst().getProductId()).isEqualTo(3L);
+        then(productRepository).should().findProductByIdsAndSortByLike(ids, pageable);
+    }
+
+    private ProductWithFirstImage stubProduct(Long id, String title, Long price, String imageUrl) {
+        return new ProductWithFirstImage() {
+            @Override
+            public Long getProductId() { return id; }
+            @Override
+            public String getTitle() { return title; }
+            @Override
+            public Long getPrice() { return price; }
+            @Override
+            public String getImageUrl() { return imageUrl; }
+        };
+    }
+}

--- a/product-service/src/test/java/hanium/product_service/service/impl/TradeReviewServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/TradeReviewServiceImplTest.java
@@ -1,0 +1,95 @@
+package hanium.product_service.service.impl;
+
+import hanium.product_service.domain.Product;
+import hanium.product_service.domain.Trade;
+import hanium.product_service.domain.TradeReview;
+import hanium.product_service.dto.request.TradeReviewRequestDTO;
+import hanium.product_service.dto.response.ProfileResponseDTO;
+import hanium.product_service.dto.response.TradeReviewPageDTO;
+import hanium.product_service.grpc.ProfileGrpcClient;
+import hanium.product_service.repository.TradeRepository;
+import hanium.product_service.repository.TradeReviewRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+@ActiveProfiles("test")
+@DisplayName("거래 평가 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class TradeReviewServiceImplTest {
+
+    @Mock
+    private TradeRepository tradeRepository;
+    @Mock
+    private TradeReviewRepository tradeReviewRepository;
+    @Mock
+    private ProfileGrpcClient profileGrpcClient;
+
+    @InjectMocks
+    private TradeReviewServiceImpl sut;
+
+    @Test
+    @DisplayName("첫 진입 시 거래 평가 페이지 정보 조회")
+    void getTradeReviewPageInfo() {
+        // given
+        Long tradeId = 1L;
+        Long memberId = 100L;
+        Long targetMemberId = 200L;
+
+        Product mockProduct = mock(Product.class);
+        given(mockProduct.getTitle()).willReturn("유모차");
+
+        Trade mockTrade = mock(Trade.class);
+        given(mockTrade.getProduct()).willReturn(mockProduct);
+        given(mockTrade.getOtherParty(memberId)).willReturn(targetMemberId);
+        given(tradeRepository.findByIdWithProduct(tradeId)).willReturn(Optional.of(mockTrade));
+
+        ProfileResponseDTO mockProfile = ProfileResponseDTO.builder().nickname("거래상대방닉네임").build();
+        given(profileGrpcClient.getProfileByMemberId(targetMemberId)).willReturn(mockProfile);
+
+        // when
+        TradeReviewPageDTO result = sut.getTradeReviewPageInfo(tradeId, memberId);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo("유모차");
+        assertThat(result.getNickname()).isEqualTo("거래상대방닉네임");
+        then(tradeRepository).should().findByIdWithProduct(tradeId);
+        then(profileGrpcClient).should().getProfileByMemberId(targetMemberId);
+    }
+
+    @Test
+    @DisplayName("거래 평가 등록")
+    void tradeReview() {
+        // given
+        TradeReviewRequestDTO dto = TradeReviewRequestDTO.builder()
+                .tradeId(1L)
+                .memberId(100L)
+                .rating(5.0)
+                .comment("완전 친절!!")
+                .build();
+
+        Trade mockTrade = mock(Trade.class);
+        given(tradeRepository.findByIdAndDeletedAtIsNull(dto.getTradeId())).willReturn(Optional.of(mockTrade));
+        given(tradeReviewRepository.existsByTradeIdAndMemberId(dto.getTradeId(), dto.getMemberId())).willReturn(false);
+
+        // when
+        sut.tradeReview(dto);
+
+        // then
+        then(tradeRepository).should().findByIdAndDeletedAtIsNull(dto.getTradeId());
+        then(tradeReviewRepository).should().existsByTradeIdAndMemberId(dto.getTradeId(), dto.getMemberId());
+        then(tradeReviewRepository).should().save(any(TradeReview.class));
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈
Closes #84

## 💼 작업 설명
상품 검색과 거래 평가 api에 대한 테스트 코드를 작성하였습니다.

## ✅ 구현/변경사항
- `TradeReviewServiceImplTest` 추가
- `ProductSearchServiceImplTest` 추가
