### PR TITLE
[feat/#86] 송장 등록 및 택배 조회 api 구현

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/TradeController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/TradeController.java
@@ -1,6 +1,7 @@
 package hanium.apigateway_service.controller;
 
-import hanium.apigateway_service.dto.product.response.TradeReviewPageDTO;
+import hanium.apigateway_service.dto.trade.request.CreateWayBillRequestDTO;
+import hanium.apigateway_service.dto.trade.response.TradeReviewPageDTO;
 import hanium.apigateway_service.dto.trade.request.TradeReviewRequestDTO;
 import hanium.apigateway_service.grpc.GrpcChatStreamClient;
 import hanium.apigateway_service.grpc.TradeGrpcClient;
@@ -179,4 +180,15 @@ public class TradeController {
         return ResponseEntity.ok(response);
     }
 
+
+    // 송장등록
+    @PostMapping("/delivery/{tradeId}")
+    public ResponseEntity<ResponseDTO<?>> createWayBill(@PathVariable Long tradeId,
+                                                        Authentication authentication,
+                                                        @RequestBody CreateWayBillRequestDTO dto) {
+        Long memberId = (Long) authentication.getPrincipal();
+        tradeGrpcClient.createWayBill(tradeId, memberId, dto);
+        ResponseDTO<?> response = new ResponseDTO<>(null, HttpStatus.OK, "송장 등록이 완료되었습니다.");
+        return ResponseEntity.ok(response);
+    }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/TradeController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/TradeController.java
@@ -1,6 +1,7 @@
 package hanium.apigateway_service.controller;
 
 import hanium.apigateway_service.dto.trade.request.CreateWayBillRequestDTO;
+import hanium.apigateway_service.dto.trade.response.DeliveryInfoResponseDTO;
 import hanium.apigateway_service.dto.trade.response.TradeReviewPageDTO;
 import hanium.apigateway_service.dto.trade.request.TradeReviewRequestDTO;
 import hanium.apigateway_service.grpc.GrpcChatStreamClient;
@@ -189,6 +190,16 @@ public class TradeController {
         Long memberId = (Long) authentication.getPrincipal();
         tradeGrpcClient.createWayBill(tradeId, memberId, dto);
         ResponseDTO<?> response = new ResponseDTO<>(null, HttpStatus.OK, "송장 등록이 완료되었습니다.");
+        return ResponseEntity.ok(response);
+    }
+
+    // 택배 조회
+    @GetMapping("/delivery/{tradeId}")
+    public ResponseEntity<ResponseDTO<DeliveryInfoResponseDTO>> getDeliveryInfo(@PathVariable Long tradeId,
+                                                                                Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        DeliveryInfoResponseDTO result = tradeGrpcClient.getDeliveryInfo(tradeId, memberId);
+        ResponseDTO<DeliveryInfoResponseDTO> response = new ResponseDTO<>(result, HttpStatus.OK, "택배 조회가 완료되었습니다.");
         return ResponseEntity.ok(response);
     }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/request/CreateWayBillRequestDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/request/CreateWayBillRequestDTO.java
@@ -1,0 +1,14 @@
+package hanium.apigateway_service.dto.trade.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateWayBillRequestDTO {
+    private String code;
+    private String invoiceNo;
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/response/DeliveryInfoResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/response/DeliveryInfoResponseDTO.java
@@ -1,0 +1,29 @@
+package hanium.apigateway_service.dto.trade.response;
+
+import hanium.common.proto.product.GetDeliveryInfoResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeliveryInfoResponseDTO {
+    private String code;
+    private String invoiceNo;
+    private List<DeliveryStatusSummaryDTO> deliveryStatus;
+
+    public static DeliveryInfoResponseDTO from(GetDeliveryInfoResponse response) {
+        List<DeliveryStatusSummaryDTO> status = response.getDeliveryStatusSummaryList().stream()
+                .map(DeliveryStatusSummaryDTO::from)
+                .toList();
+        return DeliveryInfoResponseDTO.builder()
+                .code(response.getCode())
+                .invoiceNo(response.getInvoiceNumber())
+                .deliveryStatus(status)
+                .build();
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/response/DeliveryStatusSummaryDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/response/DeliveryStatusSummaryDTO.java
@@ -1,0 +1,24 @@
+package hanium.apigateway_service.dto.trade.response;
+
+import hanium.common.proto.product.DeliveryStatusSummary;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeliveryStatusSummaryDTO {
+    private String time;
+    private String location;
+    private String status;
+
+    public static DeliveryStatusSummaryDTO from(DeliveryStatusSummary summary) {
+        return DeliveryStatusSummaryDTO.builder()
+                .time(summary.getTime())
+                .location(summary.getLocation())
+                .status(summary.getStatus())
+                .build();
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/response/TradeReviewPageDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/response/TradeReviewPageDTO.java
@@ -1,4 +1,4 @@
-package hanium.apigateway_service.dto.product.response;
+package hanium.apigateway_service.dto.trade.response;
 
 import hanium.common.proto.product.GetTradeReviewPageResponse;
 import lombok.AccessLevel;

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/TradeGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/TradeGrpcClient.java
@@ -1,6 +1,7 @@
 package hanium.apigateway_service.grpc;
 
 import hanium.apigateway_service.dto.trade.request.CreateWayBillRequestDTO;
+import hanium.apigateway_service.dto.trade.response.DeliveryInfoResponseDTO;
 import hanium.apigateway_service.dto.trade.response.TradeReviewPageDTO;
 import hanium.apigateway_service.dto.trade.request.TradeReviewRequestDTO;
 import hanium.apigateway_service.mapper.TradeGrpcMapperForGateway;
@@ -113,6 +114,15 @@ public class TradeGrpcClient {
 
     }
 
+    // 택배 조회
+    public DeliveryInfoResponseDTO getDeliveryInfo(Long tradeId, Long memberId){
+        GetDeliveryInfoRequest request = tradeGrpcMapperForGateway.toGetDeliveryInfoRequestGrpc(tradeId, memberId);
+        try {
+            return DeliveryInfoResponseDTO.from(stub.getDeliveryInfo(request));
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
 
 
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/TradeGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/TradeGrpcClient.java
@@ -1,6 +1,7 @@
 package hanium.apigateway_service.grpc;
 
-import hanium.apigateway_service.dto.product.response.TradeReviewPageDTO;
+import hanium.apigateway_service.dto.trade.request.CreateWayBillRequestDTO;
+import hanium.apigateway_service.dto.trade.response.TradeReviewPageDTO;
 import hanium.apigateway_service.dto.trade.request.TradeReviewRequestDTO;
 import hanium.apigateway_service.mapper.TradeGrpcMapperForGateway;
 import hanium.common.exception.CustomException;
@@ -99,6 +100,17 @@ public class TradeGrpcClient {
         } catch (StatusRuntimeException e) {
             throw new CustomException(GrpcUtil.extractErrorCode(e));
         }
+    }
+
+    // 송장 등록
+    public void createWayBill(Long tradeId, Long memberId, CreateWayBillRequestDTO dto){
+        CreateWayBillRequest request = tradeGrpcMapperForGateway.toCreateWayBillRequestGrpc(tradeId, memberId, dto);
+        try {
+            stub.createWayBill(request);
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+
     }
 
 

--- a/apigateway-service/src/main/java/hanium/apigateway_service/mapper/TradeGrpcMapperForGateway.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/mapper/TradeGrpcMapperForGateway.java
@@ -2,10 +2,7 @@ package hanium.apigateway_service.mapper;
 
 import hanium.apigateway_service.dto.trade.request.CreateWayBillRequestDTO;
 import hanium.apigateway_service.dto.trade.request.TradeReviewRequestDTO;
-import hanium.common.proto.product.CreateWayBillRequest;
-import hanium.common.proto.product.GetTradeReviewPageRequest;
-import hanium.common.proto.product.TradeRequest;
-import hanium.common.proto.product.TradeReviewRequest;
+import hanium.common.proto.product.*;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -39,6 +36,13 @@ public class TradeGrpcMapperForGateway {
                 .setMemberId(memberId)
                 .setCode(dto.getCode())
                 .setInvoiceNumber(dto.getInvoiceNo())
+                .build();
+    }
+
+    public GetDeliveryInfoRequest toGetDeliveryInfoRequestGrpc(Long tradeId, Long memberId){
+        return GetDeliveryInfoRequest.newBuilder()
+                .setTradeId(tradeId)
+                .setMemberId(memberId)
                 .build();
     }
 }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/mapper/TradeGrpcMapperForGateway.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/mapper/TradeGrpcMapperForGateway.java
@@ -1,6 +1,8 @@
 package hanium.apigateway_service.mapper;
 
+import hanium.apigateway_service.dto.trade.request.CreateWayBillRequestDTO;
 import hanium.apigateway_service.dto.trade.request.TradeReviewRequestDTO;
+import hanium.common.proto.product.CreateWayBillRequest;
 import hanium.common.proto.product.GetTradeReviewPageRequest;
 import hanium.common.proto.product.TradeRequest;
 import hanium.common.proto.product.TradeReviewRequest;
@@ -28,6 +30,15 @@ public class TradeGrpcMapperForGateway {
                 .setMemberId(memberId)
                 .setRating(dto.getRating())
                 .setComment(dto.getComment())
+                .build();
+    }
+
+    public CreateWayBillRequest toCreateWayBillRequestGrpc(Long tradeId, Long memberId, CreateWayBillRequestDTO dto){
+        return CreateWayBillRequest.newBuilder()
+                .setTradeId(tradeId)
+                .setMemberId(memberId)
+                .setCode(dto.getCode())
+                .setInvoiceNumber(dto.getInvoiceNo())
                 .build();
     }
 }

--- a/common/src/main/java/hanium/common/exception/ErrorCode.java
+++ b/common/src/main/java/hanium/common/exception/ErrorCode.java
@@ -57,6 +57,8 @@ public enum ErrorCode {
     ALREADY_REVIEWED(409, "이미 리뷰가 작성된 거래입니다."),
     NOT_FOUND_TRADE(400, "해당 거래는 없습니다."),
     FAIL_TRADE_DONE_CHAT(404,"거래 완료 메시지 수신 실패"),
+    DELIVERY_NOT_FOUND(404, "해당 배송 정보를 찾을 수 없습니다."),
+    API_CALL_FAIL(502, "sweet-tracker api 호출을 실해하였습니다."),
     ;
 
 

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -90,6 +90,9 @@ service ProductService {
 
   //현재 거래 상태 조회
   rpc getTradeStatus(TradeRequest) returns (TradeStatusResponse);
+  // 송장 등록
+  rpc CreateWayBill(CreateWayBillRequest) returns (Empty);
+
 }
 
 message Empty {}
@@ -370,4 +373,12 @@ message CompleteTradeResponse{
 // 주요 활동 카테고리 조회
 message GetMainCategoryResponse {
   repeated string category = 1;
+}
+
+// 송장 등록
+message CreateWayBillRequest {
+  int64 trade_id = 1;
+  int64 member_id = 2;
+  string code = 3;
+  string invoice_number = 4;
 }

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -90,8 +90,12 @@ service ProductService {
 
   //현재 거래 상태 조회
   rpc getTradeStatus(TradeRequest) returns (TradeStatusResponse);
+
   // 송장 등록
   rpc CreateWayBill(CreateWayBillRequest) returns (Empty);
+
+  // 택배 조회
+  rpc GetDeliveryInfo(GetDeliveryInfoRequest) returns (GetDeliveryInfoResponse);
 
 }
 
@@ -381,4 +385,23 @@ message CreateWayBillRequest {
   int64 member_id = 2;
   string code = 3;
   string invoice_number = 4;
+}
+
+// 택배 조회 요청
+message GetDeliveryInfoRequest {
+  int64 trade_id = 1;
+  int64 member_id = 2;
+}
+
+// 택배 조회 응답
+message GetDeliveryInfoResponse {
+  string code = 1;
+  string invoice_number = 2;
+  repeated DeliveryStatusSummary delivery_status_summary = 3;
+}
+
+message DeliveryStatusSummary{
+  string time = 1;
+  string location = 2;
+  string status = 3;
 }

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -115,6 +115,8 @@ dependencies {
 //    // Spring-Test-Support (Optional)
 //    testImplementation("org.springframework.boot:spring-boot-starter-test")
 
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // test
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:5.12.0'

--- a/product-service/src/main/java/hanium/product_service/config/WebClientConfig.java
+++ b/product-service/src/main/java/hanium/product_service/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package hanium.product_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/domain/Delivery.java
+++ b/product-service/src/main/java/hanium/product_service/domain/Delivery.java
@@ -17,7 +17,7 @@ public class Delivery extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trade_id")
     private Trade trade;
 
@@ -38,16 +38,11 @@ public class Delivery extends BaseEntity {
     @Column(name = "invoice_number")
     private String invoiceNo;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "delivery_status")
-    private DeliveryStatus status;
-
     public static Delivery of(Trade trade, CreateWayBillRequestDTO dto){
         return Delivery.builder()
                 .trade(trade)
                 .code(dto.getCode())
                 .invoiceNo(dto.getInvoiceNo())
-                .status(DeliveryStatus.PREPARING)
                 .build();
     }
 }

--- a/product-service/src/main/java/hanium/product_service/domain/Delivery.java
+++ b/product-service/src/main/java/hanium/product_service/domain/Delivery.java
@@ -1,0 +1,53 @@
+package hanium.product_service.domain;
+
+import hanium.product_service.dto.request.CreateWayBillRequestDTO;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Delivery extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trade_id")
+    private Trade trade;
+
+    /*
+     * 택배사 코드
+     * 스마트 택배 API 호출 용도
+     * 01 : 우체국 택배
+     * 04 : CJ 대한통운
+     * 05 : 한진택배
+     * 06 : 로젠택배
+     * 08 : 롯데택배
+     * 24 : GS Postbox 택배
+     * 46 : CU 편의점택배
+     */
+    @Column(name = "delivery_code")
+    private String code;
+
+    @Column(name = "invoice_number")
+    private String invoiceNo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_status")
+    private DeliveryStatus status;
+
+    public static Delivery of(Trade trade, CreateWayBillRequestDTO dto){
+        return Delivery.builder()
+                .trade(trade)
+                .code(dto.getCode())
+                .invoiceNo(dto.getInvoiceNo())
+                .status(DeliveryStatus.PREPARING)
+                .build();
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/domain/DeliveryStatus.java
+++ b/product-service/src/main/java/hanium/product_service/domain/DeliveryStatus.java
@@ -1,0 +1,22 @@
+package hanium.product_service.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum DeliveryStatus {
+    PREPARING(1, "배송준비중"),
+    PICKUP_COMPLETE(2, "집화완료"),
+    IN_TRANSIT(3, "배송중"),
+    ARRIVED_AT_HUB(4, "지점도착"),
+    OUT_FOR_DELIVERY(5, "배송출발"),
+    DELIVERED(6, "배송완료");
+
+    private final int level;
+    private final String description;
+
+    DeliveryStatus(int level, String description) {
+        this.level = level;
+        this.description = description;
+    }
+
+}

--- a/product-service/src/main/java/hanium/product_service/dto/request/CreateWayBillRequestDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/request/CreateWayBillRequestDTO.java
@@ -1,0 +1,27 @@
+package hanium.product_service.dto.request;
+
+import hanium.common.proto.product.CreateWayBillRequest;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateWayBillRequestDTO {
+    private long tradeId;
+    private long memberId;
+    private String code;
+    private String invoiceNo;
+
+    public static CreateWayBillRequestDTO from(CreateWayBillRequest request) {
+        return CreateWayBillRequestDTO.builder()
+                .tradeId(request.getTradeId())
+                .memberId(request.getMemberId())
+                .code(request.getCode())
+                .invoiceNo(request.getInvoiceNumber())
+                .build();
+    }
+
+}

--- a/product-service/src/main/java/hanium/product_service/dto/response/DeliveryInfoResponseDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/DeliveryInfoResponseDTO.java
@@ -1,0 +1,25 @@
+package hanium.product_service.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeliveryInfoResponseDTO {
+    private String code;
+    private String invoiceNo;
+    private List<DeliveryStatusSummaryDTO> deliveryStatus;
+
+    public static DeliveryInfoResponseDTO from(String code, String invoiceNo, List<DeliveryStatusSummaryDTO> deliveryStatus) {
+        return DeliveryInfoResponseDTO.builder()
+                .code(code)
+                .invoiceNo(invoiceNo)
+                .deliveryStatus(deliveryStatus)
+                .build();
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/dto/response/DeliveryStatusSummaryDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/DeliveryStatusSummaryDTO.java
@@ -1,0 +1,24 @@
+package hanium.product_service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeliveryStatusSummaryDTO {
+    @JsonProperty("timeString")
+    private String time;
+
+    @JsonProperty("where")
+    private String location;
+
+    @JsonProperty("kind")
+    private String status;
+
+}

--- a/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
@@ -482,6 +482,7 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
         }
     }
 
+    // 송장 등록
     @Override
     public void createWayBill(CreateWayBillRequest request, StreamObserver<Empty> responseObserver) {
         try {
@@ -493,4 +494,19 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
             responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
         }
     }
+
+    // 택배조회
+    @Override
+    public void getDeliveryInfo(GetDeliveryInfoRequest request, StreamObserver<GetDeliveryInfoResponse>  responseObserver) {
+        try {
+            responseObserver.onNext(
+                    TradeGrpcMapper.toGetDeliveryInfoResponseGrpc(
+                            deliveryService.getDeliveryInfo(request.getTradeId(), request.getMemberId()))
+            );
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
+
 }

--- a/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
@@ -38,6 +38,7 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
     private final ProfileGrpcClient profileGrpcClient;
     private final TradeService tradeService;
     private final TradeReviewService tradeReviewService;
+    private final DeliveryService deliveryService;
 
     // 메인페이지 조회
     @Override
@@ -475,6 +476,18 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
         try {
             List<String> result = productUserService.getMainCategoryByMemberId(request.getMemberId());
             responseObserver.onNext(GetMainCategoryResponse.newBuilder().addAllCategory(result).build());
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
+
+    @Override
+    public void createWayBill(CreateWayBillRequest request, StreamObserver<Empty> responseObserver) {
+        try {
+            CreateWayBillRequestDTO requestDTO = CreateWayBillRequestDTO.from(request);
+            deliveryService.createWayBill(requestDTO);
+            responseObserver.onNext(Empty.getDefaultInstance());
             responseObserver.onCompleted();
         } catch (CustomException e) {
             responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));

--- a/product-service/src/main/java/hanium/product_service/mapper/TradeGrpcMapper.java
+++ b/product-service/src/main/java/hanium/product_service/mapper/TradeGrpcMapper.java
@@ -1,7 +1,11 @@
 package hanium.product_service.mapper;
 
-import hanium.common.proto.product.GetTradeReviewPageResponse;
+import hanium.common.proto.product.*;
+import hanium.product_service.dto.response.DeliveryInfoResponseDTO;
+import hanium.product_service.dto.response.DeliveryStatusSummaryDTO;
 import hanium.product_service.dto.response.TradeReviewPageDTO;
+
+import java.util.stream.Collectors;
 
 public class TradeGrpcMapper {
 
@@ -9,6 +13,24 @@ public class TradeGrpcMapper {
         return GetTradeReviewPageResponse.newBuilder()
                 .setTitle(dto.getTitle())
                 .setNickname(dto.getNickname())
+                .build();
+    }
+
+    public static GetDeliveryInfoResponse toGetDeliveryInfoResponseGrpc(DeliveryInfoResponseDTO dto) {
+        return GetDeliveryInfoResponse.newBuilder()
+                .setCode(dto.getCode())
+                .setInvoiceNumber(dto.getInvoiceNo())
+                .addAllDeliveryStatusSummary(dto.getDeliveryStatus().stream()
+                        .map(TradeGrpcMapper::toDeliveryStatusSummaryGrpc)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static DeliveryStatusSummary toDeliveryStatusSummaryGrpc(DeliveryStatusSummaryDTO dto) {
+        return DeliveryStatusSummary.newBuilder()
+                .setTime(dto.getTime())
+                .setLocation(dto.getLocation())
+                .setStatus(dto.getStatus())
                 .build();
     }
 }

--- a/product-service/src/main/java/hanium/product_service/repository/DeliveryRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/DeliveryRepository.java
@@ -3,5 +3,8 @@ package hanium.product_service.repository;
 import hanium.product_service.domain.Delivery;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+    Optional<Delivery> findByTradeId(Long tradeId);
 }

--- a/product-service/src/main/java/hanium/product_service/repository/DeliveryRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/DeliveryRepository.java
@@ -1,0 +1,7 @@
+package hanium.product_service.repository;
+
+import hanium.product_service.domain.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+}

--- a/product-service/src/main/java/hanium/product_service/service/DeliveryService.java
+++ b/product-service/src/main/java/hanium/product_service/service/DeliveryService.java
@@ -1,0 +1,7 @@
+package hanium.product_service.service;
+
+import hanium.product_service.dto.request.CreateWayBillRequestDTO;
+
+public interface DeliveryService {
+    void createWayBill(CreateWayBillRequestDTO dto);
+}

--- a/product-service/src/main/java/hanium/product_service/service/DeliveryService.java
+++ b/product-service/src/main/java/hanium/product_service/service/DeliveryService.java
@@ -1,7 +1,9 @@
 package hanium.product_service.service;
 
 import hanium.product_service.dto.request.CreateWayBillRequestDTO;
+import hanium.product_service.dto.response.DeliveryInfoResponseDTO;
 
 public interface DeliveryService {
     void createWayBill(CreateWayBillRequestDTO dto);
+    DeliveryInfoResponseDTO getDeliveryInfo(Long tradeId, Long memberId);
 }

--- a/product-service/src/main/java/hanium/product_service/service/impl/DeliveryServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/DeliveryServiceImpl.java
@@ -1,0 +1,45 @@
+package hanium.product_service.service.impl;
+
+import hanium.common.exception.CustomException;
+import hanium.common.exception.ErrorCode;
+import hanium.product_service.domain.*;
+import hanium.product_service.dto.request.CreateWayBillRequestDTO;
+import hanium.product_service.repository.DeliveryRepository;
+import hanium.product_service.repository.ProductRepository;
+import hanium.product_service.repository.TradeRepository;
+import hanium.product_service.service.DeliveryService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryServiceImpl implements DeliveryService {
+    private final DeliveryRepository deliveryRepository;
+    private final TradeRepository tradeRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    @Transactional
+    public void createWayBill(CreateWayBillRequestDTO dto){
+        tradeRepository.findByIdAndDeletedAtIsNull(dto.getTradeId())
+                .orElseThrow(() -> new CustomException(ErrorCode.TRADE_NOT_FOUND));
+        Trade trade = em.getReference(Trade.class, dto.getTradeId());
+
+        // 판매자가 아닌 사람이 등록할 경우
+        if(trade.getSellerId() != dto.getMemberId())
+            throw new CustomException(ErrorCode.NO_PERMISSION);
+
+        Delivery delivery = Delivery.of(trade, dto);
+        deliveryRepository.save(delivery);
+
+        log.info("✅ {} 거래 {} 송장 등록 성공", dto.getTradeId(), dto.getInvoiceNo());
+    }
+
+}

--- a/product-service/src/main/java/hanium/product_service/service/impl/DeliveryServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/DeliveryServiceImpl.java
@@ -4,10 +4,12 @@ import hanium.common.exception.CustomException;
 import hanium.common.exception.ErrorCode;
 import hanium.product_service.domain.*;
 import hanium.product_service.dto.request.CreateWayBillRequestDTO;
+import hanium.product_service.dto.response.DeliveryInfoResponseDTO;
+import hanium.product_service.dto.response.DeliveryStatusSummaryDTO;
 import hanium.product_service.repository.DeliveryRepository;
-import hanium.product_service.repository.ProductRepository;
 import hanium.product_service.repository.TradeRepository;
 import hanium.product_service.service.DeliveryService;
+import hanium.product_service.util.SweetTrackerUtil;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
@@ -15,12 +17,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DeliveryServiceImpl implements DeliveryService {
     private final DeliveryRepository deliveryRepository;
     private final TradeRepository tradeRepository;
+    private final SweetTrackerUtil sweetTrackerUtil;
 
     @PersistenceContext
     private EntityManager em;
@@ -35,16 +40,31 @@ public class DeliveryServiceImpl implements DeliveryService {
     public void createWayBill(CreateWayBillRequestDTO dto){
         tradeRepository.findByIdAndDeletedAtIsNull(dto.getTradeId())
                 .orElseThrow(() -> new CustomException(ErrorCode.TRADE_NOT_FOUND));
-        Trade trade = em.getReference(Trade.class, dto.getTradeId());
+        Trade trade = em.find(Trade.class, dto.getTradeId());
 
         // 판매자가 아닌 사람이 등록할 경우
-        if(trade.getSellerId() != dto.getMemberId())
+        if(!trade.getSellerId().equals(dto.getMemberId()))
             throw new CustomException(ErrorCode.NO_PERMISSION);
 
         Delivery delivery = Delivery.of(trade, dto);
         deliveryRepository.save(delivery);
-
+        tradeRepository.updateStatus(trade.getChatroom().getId(), TradeStatus.SHIPPED);
         log.info("✅ {} 거래 {} 송장 등록 성공", dto.getTradeId(), dto.getInvoiceNo());
+    }
+
+    @Override
+    @Transactional
+    public DeliveryInfoResponseDTO getDeliveryInfo(Long tradeId, Long memberId){
+        Delivery delivery = deliveryRepository.findByTradeId(tradeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));
+
+        String code = delivery.getCode();
+        String invoiceNo = delivery.getInvoiceNo();
+
+        List<DeliveryStatusSummaryDTO> status =sweetTrackerUtil.fetchTrackingInfo(code, invoiceNo);
+
+        log.info("✅ {} 택배 조회 성공", invoiceNo);
+        return DeliveryInfoResponseDTO.from(code, invoiceNo, status);
     }
 
 }

--- a/product-service/src/main/java/hanium/product_service/service/impl/DeliveryServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/DeliveryServiceImpl.java
@@ -25,6 +25,11 @@ public class DeliveryServiceImpl implements DeliveryService {
     @PersistenceContext
     private EntityManager em;
 
+    /**
+     * 판매자가 송장 등록을 합니다.
+     *
+     * @param dto
+     */
     @Override
     @Transactional
     public void createWayBill(CreateWayBillRequestDTO dto){

--- a/product-service/src/main/java/hanium/product_service/service/impl/TradeReviewServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/TradeReviewServiceImpl.java
@@ -24,6 +24,13 @@ public class TradeReviewServiceImpl implements TradeReviewService {
     private final TradeReviewRepository tradeReviewRepository;
     private final ProfileGrpcClient profileGrpcClient;
 
+    /**
+     * 거래 평가 초기 화면을 위한 거래 상품 제목과 상대방 닉네임을 가져옵니다.
+     *
+     * @param tradeId
+     * @param memberId
+     * @return TradeReviewPageDTO
+     */
     @Override
     @Transactional(readOnly = true)
     public TradeReviewPageDTO getTradeReviewPageInfo(Long tradeId, Long memberId){
@@ -40,7 +47,11 @@ public class TradeReviewServiceImpl implements TradeReviewService {
                 .build();
     }
 
-
+    /**
+     * 거래 상대에 대해 거래 평가를 진행합니다.
+     *
+     * @param dto
+     */
     @Override
     @Transactional
     public void tradeReview(TradeReviewRequestDTO dto){

--- a/product-service/src/main/java/hanium/product_service/util/SweetTrackerUtil.java
+++ b/product-service/src/main/java/hanium/product_service/util/SweetTrackerUtil.java
@@ -1,0 +1,54 @@
+package hanium.product_service.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import hanium.common.exception.CustomException;
+import hanium.common.exception.ErrorCode;
+import hanium.product_service.dto.response.DeliveryStatusSummaryDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Component
+public class SweetTrackerUtil {
+    @Value("${spring.sweetTracker.api.key}")
+    private String apiKey;
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public SweetTrackerUtil(WebClient webClient, ObjectMapper objectMapper) {
+        this.webClient = webClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public List<DeliveryStatusSummaryDTO> fetchTrackingInfo(String code, String invoiceNo) {
+        try {
+            String jsonResponse = webClient.get()
+                    .uri("http://info.sweettracker.co.kr/api/v1/trackingInfo", uriBuilder -> uriBuilder
+                            .queryParam("t_key", apiKey)
+                            .queryParam("t_code", code)
+                            .queryParam("t_invoice", invoiceNo)
+                            .build())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            JsonNode node = objectMapper.readTree(jsonResponse);
+            JsonNode trackingInfo = node.path("trackingDetails");
+
+            return objectMapper.convertValue(
+                    trackingInfo,
+                    new TypeReference<List<DeliveryStatusSummaryDTO>>() {}
+            );
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.API_CALL_FAIL);
+        }
+    }
+
+}


### PR DESCRIPTION
## 💡 관련 이슈
#86 

## 💼 작업 설명
* 송장 등록 api 구현
* sweetTracker api를 이용한 택배 조회 api 구현

## ✅ 구현/변경사항
* gRPC 및 에러 코드 정의
  * 송장 등록(`CreateWayBill`) 및 배송 조회(`GetDeliveryInfo`)를 위한 .proto 파일을 작성했습니다.
  * 관련 실패 상황에 대응하기 위한 ErrorCode를 추가했습니다.
* 엔티티 및 비즈니스 로직 구현
  * 송장 정보를 저장하기 위한 Delivery 엔티티를 추가했습니다.
  * `DeliveryServiceImpl`에 송장 등록 및 배송 조회 비즈니스 로직을 구현했습니다.
  * 송장 등록 시, 해당 Trade의 상태가 `TradeStatus.SHIPPED`로 변경되도록 구현하였습니다.
* 외부 API 연동 모듈 구현
  * WebClient를 공용 Bean(`WebClientConfig`) 설정했습니다.
  * SweetTracker API 호출 및 응답 파싱을 전담하는 `SweetTrackerUtil`을 구현했습니다.
  * API 응답 처리를 위한 DTO를 정의했습니다.

## 📝 리뷰 요구사항