### PR TITLE
[fix #104] 소셜로그인 시 프로필사진/신뢰도 반영해 수정

### DIFF
--- a/user-service/src/main/java/hanium/user_service/service/impl/OAuthServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/OAuthServiceImpl.java
@@ -1,5 +1,6 @@
 package hanium.user_service.service.impl;
 
+import hanium.user_service.config.AwsConfig;
 import hanium.user_service.domain.*;
 import hanium.user_service.dto.response.*;
 import hanium.user_service.repository.MemberRepository;
@@ -57,6 +58,9 @@ public class OAuthServiceImpl implements OAuthService {
     private final ProfileRepository profileRepository;
     private final RefreshTokenRepository refreshRepository;
     private final JwtUtil jwtUtil;
+    private final AwsConfig awsConfig;
+
+    private final String DEFAULT_PROFILE = "default/default_profile.png";
 
     /**
      * application.yml에 설정된 카카오 로그인 client id와 redirect uri를 반환합니다.
@@ -218,10 +222,19 @@ public class OAuthServiceImpl implements OAuthService {
                 .email(kakaoUser.getEmail()).provider(Provider.KAKAO).role(Role.USER)
                 .isAgreeMarketing(false).isAgreeThirdParty(false)
                 .build();
+
+        String imageUrl = awsConfig.getDomain() + DEFAULT_PROFILE;
+        if (kakaoProfile.getProfileImageUrl() != null
+                && !kakaoProfile.getProfileImageUrl().isBlank()
+                && kakaoProfile.getIsDefaultImage().equals("false")) {
+            imageUrl = kakaoProfile.getProfileImageUrl();
+        }
         Profile profile = Profile.builder()
                 .nickname(kakaoProfile.getNickName())
-                .imageUrl(kakaoProfile.getProfileImageUrl())
+                .imageUrl(imageUrl)
+                .score(20L)
                 .member(member).build();
+
         memberRepository.save(member);
         profileRepository.save(profile);
         log.info("✅ [New Kakao Account Signup] Login Success: id={}", member.getId());
@@ -241,10 +254,18 @@ public class OAuthServiceImpl implements OAuthService {
                 .provider(Provider.NAVER).role(Role.USER)
                 .isAgreeMarketing(false).isAgreeThirdParty(false)
                 .build();
+
+        String imageUrl = awsConfig.getDomain() + DEFAULT_PROFILE;
+        if (naverUser.getProfileImage() != null
+                && !naverUser.getProfileImage().isBlank()) {
+            imageUrl = naverUser.getProfileImage();
+        }
         Profile profile = Profile.builder()
                 .nickname(naverUser.getNickname())
-                .imageUrl(naverUser.getProfileImage())
+                .imageUrl(imageUrl)
+                .score(20L)
                 .member(member).build();
+
         memberRepository.save(member);
         profileRepository.save(profile);
         log.info("✅ [New Naver Account Signup] Login Success: id={}", member.getId());

--- a/user-service/src/test/java/hanium/user_service/service/OAuthServiceImplTest.java
+++ b/user-service/src/test/java/hanium/user_service/service/OAuthServiceImplTest.java
@@ -1,5 +1,6 @@
 package hanium.user_service.service;
 
+import hanium.user_service.config.AwsConfig;
 import hanium.user_service.domain.*;
 import hanium.user_service.dto.response.KakaoUserResponseDTO;
 import hanium.user_service.dto.response.NaverUserResponseDTO;
@@ -41,6 +42,8 @@ class OAuthServiceImplTest {
     @Mock
     RefreshTokenRepository refreshRepository;
     @Mock
+    AwsConfig awsConfig;
+    @Mock
     JwtUtil jwtUtil;
 
     @InjectMocks
@@ -58,6 +61,8 @@ class OAuthServiceImplTest {
         given(kakaoAccount.getEmail()).willReturn("kakao@example.com");
         given(kakaoProfile.getNickName()).willReturn("카카오 닉네임");
         given(kakaoProfile.getProfileImageUrl()).willReturn("img/kakao.png");
+        given(kakaoProfile.getIsDefaultImage()).willReturn("false");
+        given(awsConfig.getDomain()).willReturn("domain");
 
         given(memberRepository.save(any(Member.class)))
                 .willAnswer(inv -> inv.getArgument(0));
@@ -102,6 +107,7 @@ class OAuthServiceImplTest {
         given(naverUser.getMobile()).willReturn("010-1234-5678");
         given(naverUser.getNickname()).willReturn("네이버 닉네임");
         given(naverUser.getProfileImage()).willReturn("img/naver.png");
+        given(awsConfig.getDomain()).willReturn("domain");
 
         given(memberRepository.save(any(Member.class)))
                 .willAnswer(inv -> inv.getArgument(0));


### PR DESCRIPTION
## 💡 관련 이슈
<!-- 관련된 이슈를 연결해주세요 -->
- Closes #104 

## 💼 작업 설명
<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->
소셜로그인 시 프로필사진/신뢰도 반영해 수정했습니다.

## ✅ 구현/변경사항
<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
- 네이버 로그인 시, 프로필사진 제공 동의 여부에 따라 피키 기본 프로필 or 네이버 프로필사진 저장
- 카카오 로그인 시, 프로필사진 제공 동의하지 않거나, 동의해도 기본 카카오 프로필인 경우 피키 기본 프로필로 회원가입하고 아닐 경우 카카오 프로필사진 저장
- 소셜로그인 시에도 일반 회원가입과 동일하게 초기 신뢰도를 20으로 설정 
- 관련 테스트코드 수정 

## 📝 리뷰 요구사항
<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->