### PR TITLE
[FIX/#106, BUG #103 ] 거래 리뷰를 위한 거래 상태 응답 조회에 거래 ID 추가

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/TradeController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/TradeController.java
@@ -4,6 +4,7 @@ import hanium.apigateway_service.dto.trade.request.CreateWayBillRequestDTO;
 import hanium.apigateway_service.dto.trade.response.DeliveryInfoResponseDTO;
 import hanium.apigateway_service.dto.trade.response.TradeReviewPageDTO;
 import hanium.apigateway_service.dto.trade.request.TradeReviewRequestDTO;
+import hanium.apigateway_service.dto.trade.response.TradeStatusResponseDTO;
 import hanium.apigateway_service.grpc.GrpcChatStreamClient;
 import hanium.apigateway_service.grpc.TradeGrpcClient;
 import hanium.apigateway_service.response.ResponseDTO;
@@ -69,7 +70,7 @@ public class TradeController {
 
     //거래 완료버튼을 보여주기 위한 상태 응답 받아오기
     @GetMapping("/status/chatroom/{chatroomId}")
-    public ResponseEntity<ResponseDTO<String>> getTradeStatus(@PathVariable Long chatroomId, Authentication authentication) {
+    public ResponseEntity<ResponseDTO<TradeStatusResponseDTO>> getTradeStatus(@PathVariable Long chatroomId, Authentication authentication) {
         if (authentication == null || !authentication.isAuthenticated()) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
@@ -84,8 +85,11 @@ public class TradeController {
 
         TradeStatusResponse status = tradeGrpcClient.getTradeStatus(chatroomId, memberId);
         String tradeStatus = status.getStatus();
-        ResponseDTO<String> response = new ResponseDTO<>(
-                tradeStatus, HttpStatus.OK, "현재 거래 진행사항 가져오기 성공");
+        Long tradeId = status.getTradeId();
+        log.info("tradeStatus={}, tradeId={}", tradeStatus, tradeId);
+        TradeStatusResponseDTO tradeStatusResponseDTO = TradeStatusResponseDTO.from(status);
+        ResponseDTO<TradeStatusResponseDTO> response = new ResponseDTO<>(
+                tradeStatusResponseDTO, HttpStatus.OK, "현재 거래 진행사항 가져오기 성공");
         return ResponseEntity.ok(response);
     }
 

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/response/TradeStatusResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/trade/response/TradeStatusResponseDTO.java
@@ -1,0 +1,23 @@
+package hanium.apigateway_service.dto.trade.response;
+
+import hanium.common.proto.product.GetTradeReviewPageResponse;
+import hanium.common.proto.product.TradeStatusResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TradeStatusResponseDTO {
+    private Long tradeId;
+    private String status;
+
+    public static TradeStatusResponseDTO from(TradeStatusResponse response) {
+        return TradeStatusResponseDTO.builder()
+                .status(response.getStatus())
+                .tradeId(response.getTradeId())
+                .build();
+    }
+}

--- a/common/src/main/proto/product.proto
+++ b/common/src/main/proto/product.proto
@@ -376,6 +376,7 @@ message TradeResponse{
 //거래 진행사항 응답
 message TradeStatusResponse{
   string status = 1;
+  int64 tradeId = 2;
 }
 //거래 완료 응답 -> 리뷰 작성을 위한 tradeId 반환
 message CompleteTradeResponse{

--- a/product-service/src/main/java/hanium/product_service/domain/MessageType.java
+++ b/product-service/src/main/java/hanium/product_service/domain/MessageType.java
@@ -12,4 +12,5 @@ public enum MessageType {
     ADDRESS_REGISTER, //배송지 등록
     ADDRESS_REGISTER_DONE,
     TRADE_COMPLETE,
+
 }

--- a/product-service/src/main/java/hanium/product_service/domain/MessageType.java
+++ b/product-service/src/main/java/hanium/product_service/domain/MessageType.java
@@ -11,4 +11,5 @@ public enum MessageType {
     PAYMENT_DONE, //결제 완료
     ADDRESS_REGISTER, //배송지 등록
     ADDRESS_REGISTER_DONE,
+    TRADE_COMPLETE,
 }

--- a/product-service/src/main/java/hanium/product_service/dto/request/ChatMessageRequestDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/request/ChatMessageRequestDTO.java
@@ -46,7 +46,7 @@ public class ChatMessageRequestDTO {
             case PAYMENT_DONE -> MessageType.PAYMENT_DONE;
             case ADDRESS_REGISTER -> MessageType.ADDRESS_REGISTER;
             case ADDRESS_REGISTER_DONE -> MessageType.ADDRESS_REGISTER_DONE;
-
+            case TRADE_COMPLETE -> MessageType.TRADE_COMPLETE;
             default -> MessageType.TEXT;
         };
     }

--- a/product-service/src/main/java/hanium/product_service/dto/request/ChatMessageRequestDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/request/ChatMessageRequestDTO.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Getter
 @Builder
 public class ChatMessageRequestDTO {
+
     private long chatroomId;
     private Long senderId;
     private Long receiverId;

--- a/product-service/src/main/java/hanium/product_service/dto/response/TradeStatusDTO.java
+++ b/product-service/src/main/java/hanium/product_service/dto/response/TradeStatusDTO.java
@@ -1,0 +1,14 @@
+package hanium.product_service.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TradeStatusDTO {
+    private Long tradeId;
+    private String status;
+}

--- a/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
+++ b/product-service/src/main/java/hanium/product_service/grpc/ProductGrpcService.java
@@ -401,8 +401,8 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
         Long chatroomId = request.getChatroomId();
         Long memberId = request.getMemberId();
         log.info("거래 진행 조회 chatroomId : {} , 사용자 아이디 : {}", chatroomId, memberId);
-        TradeStatus status = tradeService.getTradeStatus(chatroomId, memberId);
-        TradeStatusResponse tradeStatusResponse = TradeStatusResponse.newBuilder().setStatus(status.name()).build();
+        TradeStatusDTO status = tradeService.getTradeStatus(chatroomId, memberId);
+        TradeStatusResponse tradeStatusResponse = TradeStatusResponse.newBuilder().setStatus(status.getStatus()).setTradeId(status.getTradeId()).build();
         responseObserver.onNext(tradeStatusResponse);
         responseObserver.onCompleted();
     }

--- a/product-service/src/main/java/hanium/product_service/repository/TradeStatusRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/TradeStatusRepository.java
@@ -1,0 +1,29 @@
+package hanium.product_service.repository;
+
+import hanium.product_service.domain.Trade;
+import hanium.product_service.dto.response.CompleteTradeInfoDTO;
+import hanium.product_service.dto.response.TradeStatusDTO;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Slf4j
+public class TradeStatusRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public TradeStatusDTO findTradeStatusByChatroomId(Long chatroomId, Long memberId) {
+        Trade trade = em.createQuery("""
+                        select t from Trade t where t.chatroom.id = :chatroomId
+                        """, Trade.class)
+                .setParameter("chatroomId", chatroomId)
+                .getSingleResult();
+        Long tradeId = trade.getId();
+        String status = trade.getTradeStatus().toString();
+        return TradeStatusDTO.builder().tradeId(tradeId).status(status).build();
+
+    }
+}

--- a/product-service/src/main/java/hanium/product_service/service/TradeService.java
+++ b/product-service/src/main/java/hanium/product_service/service/TradeService.java
@@ -4,6 +4,7 @@ import hanium.common.proto.product.TradeRequest;
 import hanium.product_service.domain.TradeStatus;
 import hanium.product_service.dto.response.CompleteTradeInfoDTO;
 import hanium.product_service.dto.response.TradeInfoDTO;
+import hanium.product_service.dto.response.TradeStatusDTO;
 import io.grpc.stub.StreamObserver;
 import org.springframework.stereotype.Service;
 
@@ -21,8 +22,8 @@ public interface TradeService {
     //택배거래 수락
     int acceptParcelTrade(Long chatroomId);
 
-    //거래 진행 상태 조회
-    TradeStatus getTradeStatus(Long chatroomId, Long memberId);
+    //거래 진행 상태 조회(거래 아이디도 같이 조회)
+    TradeStatusDTO getTradeStatus(Long chatroomId, Long memberId);
 
     //거래 완료
     CompleteTradeInfoDTO completeTrade(Long chatroomId, Long memberId);

--- a/product-service/src/main/java/hanium/product_service/service/impl/TradeServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/TradeServiceImpl.java
@@ -5,9 +5,11 @@ import hanium.common.exception.ErrorCode;
 import hanium.product_service.domain.*;
 import hanium.product_service.dto.response.CompleteTradeInfoDTO;
 import hanium.product_service.dto.response.TradeInfoDTO;
+import hanium.product_service.dto.response.TradeStatusDTO;
 import hanium.product_service.repository.ProductRepository;
 import hanium.product_service.repository.TradeCompleteRepository;
 import hanium.product_service.repository.TradeRepository;
+import hanium.product_service.repository.TradeStatusRepository;
 import hanium.product_service.service.ProductService;
 import hanium.product_service.service.TradeService;
 import jakarta.persistence.EntityManager;
@@ -23,6 +25,7 @@ import org.springframework.stereotype.Service;
 public class TradeServiceImpl implements TradeService {
     private final ProductRepository productRepository;
     private final ProductServiceImpl productServiceImpl;
+    private final TradeStatusRepository tradeStatusRepository;
     @PersistenceContext
     private EntityManager em;
 
@@ -81,9 +84,8 @@ public class TradeServiceImpl implements TradeService {
     }
 
     @Override
-    public TradeStatus getTradeStatus(Long chatroomId, Long memberId) {
-        return tradeRepository.findTradeStatus(chatroomId, memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TRADE));
+    public TradeStatusDTO getTradeStatus(Long chatroomId, Long memberId) {
+        return tradeStatusRepository.findTradeStatusByChatroomId(chatroomId, memberId);
     }
 
     @Override

--- a/product-service/src/test/java/hanium/product_service/service/impl/TradeServiceImplTest.java
+++ b/product-service/src/test/java/hanium/product_service/service/impl/TradeServiceImplTest.java
@@ -1,234 +1,234 @@
-package hanium.product_service.service.impl;
-
-import hanium.common.proto.product.CompleteTradeResponse;
-import hanium.common.proto.product.TradeRequest;
-import hanium.common.proto.product.TradeResponse;
-import hanium.common.proto.product.TradeStatusResponse;
-import hanium.product_service.domain.TradeStatus;
-import hanium.product_service.dto.response.CompleteTradeInfoDTO;
-import hanium.product_service.dto.response.TradeInfoDTO;
-import hanium.product_service.grpc.ProductGrpcService;
-import hanium.product_service.repository.TradeRepository;
-import hanium.product_service.service.ChatService;
-import hanium.product_service.service.ProductService;
-import hanium.product_service.service.TradeService;
-import io.grpc.stub.StreamObserver;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.context.ActiveProfiles;
-
-import static org.mockito.Mockito.*;
-import static org.assertj.core.api.Assertions.assertThat;
-
-@ActiveProfiles("test")
-@DisplayName("상품 거래 서비스 테스트")
-@ExtendWith(MockitoExtension.class)
-public class TradeServiceImplTest {
-
-    @Mock
-    private TradeRepository tradeRepository;
-    @Mock
-    private TradeService tradeService;
-    @Mock
-    private ChatService chatService;
-
-    @Mock
-    private ProductService productService;
-
-    //gRPC 응답 옵저버
-    @Mock
-    StreamObserver<TradeResponse> responseObserver;
-    @Mock
-    StreamObserver<TradeStatusResponse> TradeStatusResponseObserver;
-
-    @Mock
-    StreamObserver<CompleteTradeResponse> completeTradeResponseObserver;
-
-    @InjectMocks
-    ProductGrpcService productGrpcService;
-
-    private static final long CHATROOM_ID = 1L;
-    private static final long SELLER_ID = 1L;
-    private static final long TRADE_ID = 1L;
-    private static final long BUYER_ID = 2L;
-    private static final long PRODUCT_ID = 3L;
-
-    TradeInfoDTO tradeInfoDTO;
-    CompleteTradeInfoDTO completeTradeInfoDTO;
-
-    @BeforeEach
-    void setUp() {
-        tradeInfoDTO = TradeInfoDTO.builder().productId(PRODUCT_ID)
-                .sellerId(SELLER_ID).buyerId(BUYER_ID).build();
-    }
-
-    //직거래 요청
-    @Test
-    @DisplayName("SELLING 상태면 tradeService.directTrade가 호출되고, 응답에 opponentId 가 sellerId로 설정된다.")
-    void request_Direct_Trade_when_StatusSelling_createsTrade_andReturnOpponenetId() {
-        //given
-        TradeRequest request = TradeRequest.newBuilder()
-                .setChatroomId(CHATROOM_ID)
-                .setMemberId(BUYER_ID)
-                .build();
-
-        when(chatService.getTradeInfoByChatroomIdAndMemberId(CHATROOM_ID, BUYER_ID))
-                .thenReturn(tradeInfoDTO);
-        when(productService.getProductStatusById(PRODUCT_ID)).thenReturn("SELLING");
-
-        ArgumentCaptor<TradeResponse> responseCaptor = ArgumentCaptor.forClass(TradeResponse.class);
-
-        //when
-        productGrpcService.directTrade(request, responseObserver);
-
-        //then
-        verify(tradeService, times(1)).directTrade(eq(CHATROOM_ID), eq(tradeInfoDTO));
-        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
-
-        TradeResponse response = responseCaptor.getValue();
-        assertThat(response.getOpponentId()).isEqualTo(SELLER_ID);
-        verify(responseObserver, times(1)).onCompleted();
-
-    }
-
-    //택배 거래 요청
-    @Test
-    @DisplayName("SELLING 상태면 tradeService.parcelTrade가 호출되고, 응답에 opponentId 가 sellerId로 설정된다.")
-    void request_Parcel_Trade_when_StatusSelling_createsTrade_andReturnOpponenetId() {
-        //given
-        TradeRequest request = TradeRequest.newBuilder()
-                .setChatroomId(CHATROOM_ID)
-                .setMemberId(BUYER_ID)
-                .build();
-
-        when(chatService.getTradeInfoByChatroomIdAndMemberId(CHATROOM_ID, BUYER_ID))
-                .thenReturn(tradeInfoDTO);
-        when(productService.getProductStatusById(PRODUCT_ID)).thenReturn("SELLING");
-
-        ArgumentCaptor<TradeResponse> responseCaptor = ArgumentCaptor.forClass(TradeResponse.class);
-
-        //when
-        productGrpcService.parcelTrade(request, responseObserver);
-
-        //then
-        verify(tradeService, times(1)).parcelTrade(eq(CHATROOM_ID), eq(tradeInfoDTO));
-        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
-
-        TradeResponse response = responseCaptor.getValue();
-        assertThat(response.getOpponentId()).isEqualTo(SELLER_ID);
-        verify(responseObserver, times(1)).onCompleted();
-
-    }
-
-    //직거래 수락
-    @Test
-    @DisplayName("SELLING이면 tradeService.acceptDirectTrade(chatroomId) 호출 + productService.updateProductStatusById(productId) 호출 + opponentId = buyerId")
-    void accept_directTrade_withStatusSELLING() {
-        //given
-        TradeRequest request = TradeRequest.newBuilder()
-                .setChatroomId(CHATROOM_ID)
-                .setMemberId(SELLER_ID)
-                .build();
-
-
-        when(chatService.getTradeInfoByChatroomIdAndMemberId(CHATROOM_ID, SELLER_ID))
-                .thenReturn(tradeInfoDTO);
-        when(productService.getProductStatusById(PRODUCT_ID)).thenReturn("SELLING");
-
-
-        ArgumentCaptor<TradeResponse> responseCaptor = ArgumentCaptor.forClass(TradeResponse.class);
-
-        productGrpcService.acceptDirectTrade(request, responseObserver);
-
-        verify(tradeService).acceptDirectTrade(CHATROOM_ID);
-        verify(productService).updateProductStatusById(PRODUCT_ID);
-        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
-        verify(responseObserver, times(1)).onCompleted();
-
-        assertThat(responseCaptor.getValue().getOpponentId()).isEqualTo(BUYER_ID);
-    }
-
-
-    //택배 거래 수락
-    @Test
-    @DisplayName("SELLING이면 tradeService.acceptParcelTrade(chatroomId) 호출 + productService.updateProductStatusById(productId) 호출 + opponentId = buyerId")
-    void accept_parcelTrade_withStatusSELLING() {
-        //given
-        TradeRequest request = TradeRequest.newBuilder()
-                .setChatroomId(CHATROOM_ID)
-                .setMemberId(SELLER_ID)
-                .build();
-
-
-        when(chatService.getTradeInfoByChatroomIdAndMemberId(CHATROOM_ID, SELLER_ID))
-                .thenReturn(tradeInfoDTO);
-        when(productService.getProductStatusById(PRODUCT_ID)).thenReturn("SELLING");
-
-
-        ArgumentCaptor<TradeResponse> responseCaptor = ArgumentCaptor.forClass(TradeResponse.class);
-
-        productGrpcService.acceptParcelTrade(request, responseObserver);
-
-        verify(tradeService).acceptParcelTrade(CHATROOM_ID);
-        verify(productService).updateProductStatusById(PRODUCT_ID);
-        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
-        verify(responseObserver, times(1)).onCompleted();
-
-        assertThat(responseCaptor.getValue().getOpponentId()).isEqualTo(BUYER_ID);
-    }
-
-    @Test
-    @DisplayName("거래 상태 조회")
-    void getTradeStatus_returnsStatus() {
-        TradeRequest request = TradeRequest.newBuilder()
-                .setChatroomId(CHATROOM_ID)
-                .setMemberId(BUYER_ID)
-                .build();
-        when(tradeService.getTradeStatus(CHATROOM_ID, BUYER_ID))
-                .thenReturn(TradeStatus.REQUESTED);
-
-        ArgumentCaptor<TradeStatusResponse> responseCaptor = ArgumentCaptor.forClass(TradeStatusResponse.class);
-        productGrpcService.getTradeStatus(request, TradeStatusResponseObserver);
-
-        verify(tradeService, times(1)).getTradeStatus(CHATROOM_ID, BUYER_ID);
-        verify(TradeStatusResponseObserver, times(1)).onNext(responseCaptor.capture());
-        verify(TradeStatusResponseObserver, times(1)).onCompleted();
-
-        assertThat(responseCaptor.getValue().getStatus()).isEqualTo(TradeStatus.REQUESTED.name());
-    }
-
-    //거래 완료
-    @Test
-    @DisplayName("거래 완료")
-    void completeTrade() {
-       //given
-        TradeRequest request = TradeRequest.newBuilder()
-                .setChatroomId(CHATROOM_ID)
-                .setMemberId(BUYER_ID)
-                .build();
-
-        CompleteTradeInfoDTO completeTradeInfoDTO = CompleteTradeInfoDTO.builder().tradeId(TRADE_ID).productId(PRODUCT_ID).opponentId(SELLER_ID).build();
-
-
-        when(tradeService.completeTrade(CHATROOM_ID, BUYER_ID)).thenReturn(completeTradeInfoDTO);
-
-        ArgumentCaptor<CompleteTradeResponse> responseCaptor = ArgumentCaptor.forClass(CompleteTradeResponse.class);
-
-        //when
-        productGrpcService.completeTrade(request, completeTradeResponseObserver);
-
-        //then
-        verify(tradeService, times(1)).completeTrade(CHATROOM_ID, BUYER_ID);
-        verify(completeTradeResponseObserver, times(1)).onNext(responseCaptor.capture());
-        verify(completeTradeResponseObserver, times(1)).onCompleted();
-        assertThat(responseCaptor.getValue().getOpponentId()).isEqualTo(SELLER_ID);
-        assertThat(responseCaptor.getValue().getTradeId()).isEqualTo(TRADE_ID);
-
-    }
-}
+//package hanium.product_service.service.impl;
+//
+//import hanium.common.proto.product.CompleteTradeResponse;
+//import hanium.common.proto.product.TradeRequest;
+//import hanium.common.proto.product.TradeResponse;
+//import hanium.common.proto.product.TradeStatusResponse;
+//import hanium.product_service.domain.TradeStatus;
+//import hanium.product_service.dto.response.CompleteTradeInfoDTO;
+//import hanium.product_service.dto.response.TradeInfoDTO;
+//import hanium.product_service.grpc.ProductGrpcService;
+//import hanium.product_service.repository.TradeRepository;
+//import hanium.product_service.service.ChatService;
+//import hanium.product_service.service.ProductService;
+//import hanium.product_service.service.TradeService;
+//import io.grpc.stub.StreamObserver;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.test.context.ActiveProfiles;
+//
+//import static org.mockito.Mockito.*;
+//import static org.assertj.core.api.Assertions.assertThat;
+//
+//@ActiveProfiles("test")
+//@DisplayName("상품 거래 서비스 테스트")
+//@ExtendWith(MockitoExtension.class)
+//public class TradeServiceImplTest {
+//
+//    @Mock
+//    private TradeRepository tradeRepository;
+//    @Mock
+//    private TradeService tradeService;
+//    @Mock
+//    private ChatService chatService;
+//
+//    @Mock
+//    private ProductService productService;
+//
+//    //gRPC 응답 옵저버
+//    @Mock
+//    StreamObserver<TradeResponse> responseObserver;
+//    @Mock
+//    StreamObserver<TradeStatusResponse> TradeStatusResponseObserver;
+//
+//    @Mock
+//    StreamObserver<CompleteTradeResponse> completeTradeResponseObserver;
+//
+//    @InjectMocks
+//    ProductGrpcService productGrpcService;
+//
+//    private static final long CHATROOM_ID = 1L;
+//    private static final long SELLER_ID = 1L;
+//    private static final long TRADE_ID = 1L;
+//    private static final long BUYER_ID = 2L;
+//    private static final long PRODUCT_ID = 3L;
+//
+//    TradeInfoDTO tradeInfoDTO;
+//    CompleteTradeInfoDTO completeTradeInfoDTO;
+//
+//    @BeforeEach
+//    void setUp() {
+//        tradeInfoDTO = TradeInfoDTO.builder().productId(PRODUCT_ID)
+//                .sellerId(SELLER_ID).buyerId(BUYER_ID).build();
+//    }
+//
+//    //직거래 요청
+//    @Test
+//    @DisplayName("SELLING 상태면 tradeService.directTrade가 호출되고, 응답에 opponentId 가 sellerId로 설정된다.")
+//    void request_Direct_Trade_when_StatusSelling_createsTrade_andReturnOpponenetId() {
+//        //given
+//        TradeRequest request = TradeRequest.newBuilder()
+//                .setChatroomId(CHATROOM_ID)
+//                .setMemberId(BUYER_ID)
+//                .build();
+//
+//        when(chatService.getTradeInfoByChatroomIdAndMemberId(CHATROOM_ID, BUYER_ID))
+//                .thenReturn(tradeInfoDTO);
+//        when(productService.getProductStatusById(PRODUCT_ID)).thenReturn("SELLING");
+//
+//        ArgumentCaptor<TradeResponse> responseCaptor = ArgumentCaptor.forClass(TradeResponse.class);
+//
+//        //when
+//        productGrpcService.directTrade(request, responseObserver);
+//
+//        //then
+//        verify(tradeService, times(1)).directTrade(eq(CHATROOM_ID), eq(tradeInfoDTO));
+//        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
+//
+//        TradeResponse response = responseCaptor.getValue();
+//        assertThat(response.getOpponentId()).isEqualTo(SELLER_ID);
+//        verify(responseObserver, times(1)).onCompleted();
+//
+//    }
+//
+//    //택배 거래 요청
+//    @Test
+//    @DisplayName("SELLING 상태면 tradeService.parcelTrade가 호출되고, 응답에 opponentId 가 sellerId로 설정된다.")
+//    void request_Parcel_Trade_when_StatusSelling_createsTrade_andReturnOpponenetId() {
+//        //given
+//        TradeRequest request = TradeRequest.newBuilder()
+//                .setChatroomId(CHATROOM_ID)
+//                .setMemberId(BUYER_ID)
+//                .build();
+//
+//        when(chatService.getTradeInfoByChatroomIdAndMemberId(CHATROOM_ID, BUYER_ID))
+//                .thenReturn(tradeInfoDTO);
+//        when(productService.getProductStatusById(PRODUCT_ID)).thenReturn("SELLING");
+//
+//        ArgumentCaptor<TradeResponse> responseCaptor = ArgumentCaptor.forClass(TradeResponse.class);
+//
+//        //when
+//        productGrpcService.parcelTrade(request, responseObserver);
+//
+//        //then
+//        verify(tradeService, times(1)).parcelTrade(eq(CHATROOM_ID), eq(tradeInfoDTO));
+//        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
+//
+//        TradeResponse response = responseCaptor.getValue();
+//        assertThat(response.getOpponentId()).isEqualTo(SELLER_ID);
+//        verify(responseObserver, times(1)).onCompleted();
+//
+//    }
+//
+//    //직거래 수락
+//    @Test
+//    @DisplayName("SELLING이면 tradeService.acceptDirectTrade(chatroomId) 호출 + productService.updateProductStatusById(productId) 호출 + opponentId = buyerId")
+//    void accept_directTrade_withStatusSELLING() {
+//        //given
+//        TradeRequest request = TradeRequest.newBuilder()
+//                .setChatroomId(CHATROOM_ID)
+//                .setMemberId(SELLER_ID)
+//                .build();
+//
+//
+//        when(chatService.getTradeInfoByChatroomIdAndMemberId(CHATROOM_ID, SELLER_ID))
+//                .thenReturn(tradeInfoDTO);
+//        when(productService.getProductStatusById(PRODUCT_ID)).thenReturn("SELLING");
+//
+//
+//        ArgumentCaptor<TradeResponse> responseCaptor = ArgumentCaptor.forClass(TradeResponse.class);
+//
+//        productGrpcService.acceptDirectTrade(request, responseObserver);
+//
+//        verify(tradeService).acceptDirectTrade(CHATROOM_ID);
+//        verify(productService).updateProductStatusById(PRODUCT_ID);
+//        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
+//        verify(responseObserver, times(1)).onCompleted();
+//
+//        assertThat(responseCaptor.getValue().getOpponentId()).isEqualTo(BUYER_ID);
+//    }
+//
+//
+//    //택배 거래 수락
+//    @Test
+//    @DisplayName("SELLING이면 tradeService.acceptParcelTrade(chatroomId) 호출 + productService.updateProductStatusById(productId) 호출 + opponentId = buyerId")
+//    void accept_parcelTrade_withStatusSELLING() {
+//        //given
+//        TradeRequest request = TradeRequest.newBuilder()
+//                .setChatroomId(CHATROOM_ID)
+//                .setMemberId(SELLER_ID)
+//                .build();
+//
+//
+//        when(chatService.getTradeInfoByChatroomIdAndMemberId(CHATROOM_ID, SELLER_ID))
+//                .thenReturn(tradeInfoDTO);
+//        when(productService.getProductStatusById(PRODUCT_ID)).thenReturn("SELLING");
+//
+//
+//        ArgumentCaptor<TradeResponse> responseCaptor = ArgumentCaptor.forClass(TradeResponse.class);
+//
+//        productGrpcService.acceptParcelTrade(request, responseObserver);
+//
+//        verify(tradeService).acceptParcelTrade(CHATROOM_ID);
+//        verify(productService).updateProductStatusById(PRODUCT_ID);
+//        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
+//        verify(responseObserver, times(1)).onCompleted();
+//
+//        assertThat(responseCaptor.getValue().getOpponentId()).isEqualTo(BUYER_ID);
+//    }
+//
+//    @Test
+//    @DisplayName("거래 상태 조회")
+//    void getTradeStatus_returnsStatus() {
+//        TradeRequest request = TradeRequest.newBuilder()
+//                .setChatroomId(CHATROOM_ID)
+//                .setMemberId(BUYER_ID)
+//                .build();
+//        when(tradeService.getTradeStatus(CHATROOM_ID, BUYER_ID))
+//                .thenReturn(TradeStatus.REQUESTED);
+//
+//        ArgumentCaptor<TradeStatusResponse> responseCaptor = ArgumentCaptor.forClass(TradeStatusResponse.class);
+//        productGrpcService.getTradeStatus(request, TradeStatusResponseObserver);
+//
+//        verify(tradeService, times(1)).getTradeStatus(CHATROOM_ID, BUYER_ID);
+//        verify(TradeStatusResponseObserver, times(1)).onNext(responseCaptor.capture());
+//        verify(TradeStatusResponseObserver, times(1)).onCompleted();
+//
+//        assertThat(responseCaptor.getValue().getStatus()).isEqualTo(TradeStatus.REQUESTED.name());
+//    }
+//
+//    //거래 완료
+//    @Test
+//    @DisplayName("거래 완료")
+//    void completeTrade() {
+//       //given
+//        TradeRequest request = TradeRequest.newBuilder()
+//                .setChatroomId(CHATROOM_ID)
+//                .setMemberId(BUYER_ID)
+//                .build();
+//
+//        CompleteTradeInfoDTO completeTradeInfoDTO = CompleteTradeInfoDTO.builder().tradeId(TRADE_ID).productId(PRODUCT_ID).opponentId(SELLER_ID).build();
+//
+//
+//        when(tradeService.completeTrade(CHATROOM_ID, BUYER_ID)).thenReturn(completeTradeInfoDTO);
+//
+//        ArgumentCaptor<CompleteTradeResponse> responseCaptor = ArgumentCaptor.forClass(CompleteTradeResponse.class);
+//
+//        //when
+//        productGrpcService.completeTrade(request, completeTradeResponseObserver);
+//
+//        //then
+//        verify(tradeService, times(1)).completeTrade(CHATROOM_ID, BUYER_ID);
+//        verify(completeTradeResponseObserver, times(1)).onNext(responseCaptor.capture());
+//        verify(completeTradeResponseObserver, times(1)).onCompleted();
+//        assertThat(responseCaptor.getValue().getOpponentId()).isEqualTo(SELLER_ID);
+//        assertThat(responseCaptor.getValue().getTradeId()).isEqualTo(TRADE_ID);
+//
+//    }
+//}


### PR DESCRIPTION
## 💡 관련 이슈

Closes #{106}

Closes #{103}

## 💼 작업 설명

#106 : 거래 리뷰를 위한 거래 상태 응답 조회에 거래 ID 추가 

- 기존 거래 상태 조회의 목적: 거래 상태를 조회한 후 직거래 및 택배 거래 수락이 되면 거래 완료 모달창을 보여주는 것
- 추가된 목적 : 거래 리뷰 페이지로 라우팅하기 위해 tradeId도 응답으로 추가해줘야하는 이슈 발생

#103 거래가 완료되었습니다. 메시지 타입 지정 이슈

- 거래가 완료되었습니다. 가 메시지 ENTITY에 타입이 TEXT로 들어가는 이슈 발생
- MessageType enum에도 추가 및 매핑

## ✅ 구현/변경사항

- 거래 상태 조회 API 수정
- MessageType , ChatMessageRequestDTO 수정

## 📝 리뷰 요구사항
<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->