### PR TITLE
[feat #112] 타 사용자 프로필 조회 API 구현 

### DIFF
--- a/apigateway-service/src/main/java/hanium/apigateway_service/controller/ProfileController.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/controller/ProfileController.java
@@ -2,6 +2,7 @@ package hanium.apigateway_service.controller;
 
 import hanium.apigateway_service.dto.product.response.SimpleProductDTO;
 import hanium.apigateway_service.dto.user.request.UpdateProfileRequestDTO;
+import hanium.apigateway_service.dto.user.response.OtherProfileResponseDTO;
 import hanium.apigateway_service.dto.user.response.PresignedUrlResponseDTO;
 import hanium.apigateway_service.dto.user.response.ProfileDetailResponseDTO;
 import hanium.apigateway_service.dto.user.response.ProfileResponseDTO;
@@ -55,6 +56,18 @@ public class ProfileController {
         ProfileDetailResponseDTO responseDTO = userGrpcClient.getDetailProfile(memberId);
         ResponseDTO<ProfileDetailResponseDTO> result = new ResponseDTO<>(
                 responseDTO, HttpStatus.OK, "나의 프로필이 조회되었습니다."
+        );
+        return ResponseEntity.ok(result);
+    }
+
+    // 상대 프로필 상세 조회
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ResponseDTO<OtherProfileResponseDTO>> getOtherProfile(Authentication authentication,
+                                                                                @PathVariable Long memberId) {
+        Long myId = (Long) authentication.getPrincipal();
+        OtherProfileResponseDTO dto = userGrpcClient.getOtherProfile(myId, memberId);
+        ResponseDTO<OtherProfileResponseDTO> result = new ResponseDTO<>(
+                dto, HttpStatus.OK, "ID=" + memberId + "의 프로필이 조회되었습니다."
         );
         return ResponseEntity.ok(result);
     }

--- a/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/OtherProfileResponseDTO.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/dto/user/response/OtherProfileResponseDTO.java
@@ -1,0 +1,28 @@
+package hanium.apigateway_service.dto.user.response;
+
+import hanium.apigateway_service.dto.product.response.SimpleProductDTO;
+import hanium.common.proto.user.GetOtherProfileResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OtherProfileResponseDTO(
+        Long memberId,
+        String nickname,
+        String imageUrl,
+        Long score,
+        List<String> mainCategory,
+        List<SimpleProductDTO> products
+) {
+    public static OtherProfileResponseDTO from(GetOtherProfileResponse response) {
+        return OtherProfileResponseDTO.builder()
+                .memberId(response.getMemberId())
+                .nickname(response.getNickname())
+                .imageUrl(response.getImageUrl())
+                .score(response.getScore())
+                .mainCategory(response.getMainCategoryList().stream().toList())
+                .products(response.getProductsList().stream().map(SimpleProductDTO::from).toList())
+                .build();
+    }
+}

--- a/apigateway-service/src/main/java/hanium/apigateway_service/grpc/UserGrpcClient.java
+++ b/apigateway-service/src/main/java/hanium/apigateway_service/grpc/UserGrpcClient.java
@@ -4,12 +4,14 @@ import hanium.apigateway_service.dto.user.request.LoginRequestDTO;
 import hanium.apigateway_service.dto.user.request.SignUpRequestDTO;
 import hanium.apigateway_service.dto.user.request.UpdateProfileRequestDTO;
 import hanium.apigateway_service.dto.user.request.VerifySmsRequestDTO;
+import hanium.apigateway_service.dto.user.response.OtherProfileResponseDTO;
 import hanium.apigateway_service.dto.user.response.PresignedUrlResponseDTO;
 import hanium.apigateway_service.dto.user.response.ProfileDetailResponseDTO;
 import hanium.apigateway_service.dto.user.response.ProfileResponseDTO;
 import hanium.apigateway_service.mapper.UserGrpcMapperForGateway;
 import hanium.apigateway_service.security.JwtUtil;
 import hanium.common.exception.CustomException;
+import hanium.common.exception.ErrorCode;
 import hanium.common.exception.GrpcUtil;
 import hanium.common.proto.common.Empty;
 import hanium.common.proto.user.*;
@@ -181,6 +183,19 @@ public class UserGrpcClient {
         GetProfileRequest request = GetProfileRequest.newBuilder().setMemberId(memberId).build();
         try {
             return stub.toggleThirdParty(request).getMessage();
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
+
+    // 타 사용자 프로필 조회
+    public OtherProfileResponseDTO getOtherProfile(Long myId, Long memberId) {
+        if (myId.equals(memberId)) {
+            throw new CustomException(ErrorCode.OTHER_PROFILE_ERROR);
+        }
+        GetProfileRequest request = GetProfileRequest.newBuilder().setMemberId(memberId).build();
+        try {
+            return OtherProfileResponseDTO.from(stub.getOtherProfile(request));
         } catch (StatusRuntimeException e) {
             throw new CustomException(GrpcUtil.extractErrorCode(e));
         }

--- a/common/src/main/java/hanium/common/exception/ErrorCode.java
+++ b/common/src/main/java/hanium/common/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     AUTHORITY_NOT_FOUND(404, "사용자의 권한을 조회할 수 없습니다."),
     REFRESH_NOT_FOUND(404, "데이터베이스에서 Refresh 토큰을 찾을 수 없습니다."),
     INVALID_PROFILE_IMAGE_TYPE(400, "프로필 사진은 image 형식만 등록할 수 있습니다."),
+    OTHER_PROFILE_ERROR(400, "내 프로필은 '상대 프로필 조회' API로 조회할 수 없습니다."),
 
     // -- PRODUCT-SERVICE -- //
     ERROR_ADD_PRODUCT(500, "상품 등록 중 문제가 발생했습니다."),
@@ -60,7 +61,7 @@ public enum ErrorCode {
     FORBIDDEN(403, "해당 요청에 대한 권한이 없습니다."),
     ALREADY_REVIEWED(409, "이미 리뷰가 작성된 거래입니다."),
     NOT_FOUND_TRADE(400, "해당 거래는 없습니다."),
-    FAIL_TRADE_DONE_CHAT(404,"거래 완료 메시지 수신 실패"),
+    FAIL_TRADE_DONE_CHAT(404, "거래 완료 메시지 수신 실패"),
     DELIVERY_NOT_FOUND(404, "해당 배송 정보를 찾을 수 없습니다."),
     API_CALL_FAIL(502, "sweet-tracker api 호출을 실해하였습니다."),
     ;

--- a/common/src/main/proto/user.proto
+++ b/common/src/main/proto/user.proto
@@ -6,6 +6,7 @@ option java_package = "hanium.common.proto.user";
 option java_multiple_files = true;
 
 import "common.proto";  // common.proto 파일 import
+import "product.proto";
 
 service UserService {
   // 1. 사용자 회원가입
@@ -57,6 +58,9 @@ service UserService {
 
   // 15. 신뢰도 업데이트
   rpc UpdateScore(UpdateScoreRequest) returns (Empty);
+
+  // 16. 상대 프로필 조회
+  rpc GetOtherProfile(GetProfileRequest) returns (GetOtherProfileResponse);
 }
 
 // 1. 회원가입
@@ -196,4 +200,14 @@ message UpdateProfileRequest {
 message UpdateScoreRequest {
   int64 member_id = 1;
   int32 amount = 2;
+}
+
+// 16. 상대 프로필 조회
+message GetOtherProfileResponse {
+  int64 member_id = 1;
+  string nickname = 2;
+  string image_url = 3;
+  int64 score = 4;
+  repeated string main_category = 5;
+  repeated product.SimpleProductResponse products = 6;
 }

--- a/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
+++ b/product-service/src/main/java/hanium/product_service/repository/ProductRepository.java
@@ -242,20 +242,15 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query(
             value = """
                     select p.category
-                    from Product p
-                    where p.sellerId = :memberId
-                    and p.deletedAt is null
+                    from product p
+                    where p.seller_id = :memberId
                     group by p.category
-                    order by count(p) desc
+                    order by count(*) desc
+                    limit 2
                     """,
-            countQuery = """
-                    select count(distinct p.category)
-                    from Product p
-                    where p.sellerId = :memberId
-                    and p.deletedAt is null
-                    """
+            nativeQuery = true
     )
-    Page<Category> findProductCategoryBySellerId(@Param("memberId") Long memberId, Pageable pageable);
+    List<Category> findProductCategoryBySellerId(@Param("memberId") Long memberId);
 
     // memberId로 product 조회
     @Query(

--- a/product-service/src/main/java/hanium/product_service/service/impl/ProductUserServiceImpl.java
+++ b/product-service/src/main/java/hanium/product_service/service/impl/ProductUserServiceImpl.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -27,19 +26,8 @@ public class ProductUserServiceImpl implements ProductUserService {
     // memberId별 판매 상품 기반한 주요 활동 카테고리 최대 2개 반환
     @Override
     public List<String> getMainCategoryByMemberId(Long memberId) {
-        Pageable pageable = PageRequest.of(0, 100);
-        Page<Category> productList = productRepository.findProductCategoryBySellerId(memberId, pageable);
-        List<String> result = new ArrayList<>();
-        for (Category item : productList) {
-            String label = item.getLabel();
-            if (!result.contains(label)) {
-                result.add(label);
-            }
-            if (result.size() == 2) {
-                return result;
-            }
-        }
-        return result;
+        List<Category> productList = productRepository.findProductCategoryBySellerId(memberId);
+        return productList.stream().map(Category::getLabel).toList();
     }
 
     // memberId가 sellerId인 상품 목록 반환

--- a/user-service/src/main/java/hanium/user_service/domain/Profile.java
+++ b/user-service/src/main/java/hanium/user_service/domain/Profile.java
@@ -6,9 +6,6 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Entity
 @Getter
 @Builder
@@ -34,12 +31,6 @@ public class Profile extends BaseEntity {
     @Column
     private Long score;
 
-    @ElementCollection(fetch = FetchType.LAZY)
-    List<String> mainCategory;
-
-    @Column(name = "main_category_ttl")
-    LocalDateTime mainCategoryTTL;
-
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;
@@ -47,11 +38,6 @@ public class Profile extends BaseEntity {
     public void update(String nickname, String imageUrl) {
         this.nickname = nickname;
         this.imageUrl = imageUrl;
-    }
-
-    public void updateMainCategory(List<String> mainCategory, LocalDateTime mainCategoryTTL) {
-        this.mainCategory = mainCategory;
-        this.mainCategoryTTL = mainCategoryTTL;
     }
 
     public void addScore(Long score) {

--- a/user-service/src/main/java/hanium/user_service/dto/response/OtherProfileResponseDTO.java
+++ b/user-service/src/main/java/hanium/user_service/dto/response/OtherProfileResponseDTO.java
@@ -1,0 +1,27 @@
+package hanium.user_service.dto.response;
+
+import hanium.common.proto.user.GetOtherProfileResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OtherProfileResponseDTO(
+        Long memberId,
+        String nickname,
+        String imageUrl,
+        Long score,
+        List<String> mainCategory,
+        List<SimpleProductDTO> products
+) {
+    public static OtherProfileResponseDTO from(GetOtherProfileResponse response) {
+        return OtherProfileResponseDTO.builder()
+                .memberId(response.getMemberId())
+                .nickname(response.getNickname())
+                .imageUrl(response.getImageUrl())
+                .score(response.getScore())
+                .mainCategory(response.getMainCategoryList().stream().toList())
+                .products(response.getProductsList().stream().map(SimpleProductDTO::from).toList())
+                .build();
+    }
+}

--- a/user-service/src/main/java/hanium/user_service/dto/response/SimpleProductDTO.java
+++ b/user-service/src/main/java/hanium/user_service/dto/response/SimpleProductDTO.java
@@ -1,0 +1,21 @@
+package hanium.user_service.dto.response;
+
+import hanium.common.proto.product.SimpleProductResponse;
+import lombok.Builder;
+
+@Builder
+public record SimpleProductDTO(
+        Long productId,
+        String title,
+        Long price,
+        String imageUrl
+) {
+    public static SimpleProductDTO from(SimpleProductResponse res) {
+        return SimpleProductDTO.builder()
+                .productId(res.getProductId())
+                .title(res.getTitle())
+                .price(res.getPrice())
+                .imageUrl(res.getImageUrl())
+                .build();
+    }
+}

--- a/user-service/src/main/java/hanium/user_service/grpc/ProductUserGrpcClient.java
+++ b/user-service/src/main/java/hanium/user_service/grpc/ProductUserGrpcClient.java
@@ -4,6 +4,7 @@ import hanium.common.exception.CustomException;
 import hanium.common.exception.GrpcUtil;
 import hanium.common.proto.product.ProductMainRequest;
 import hanium.common.proto.product.ProductServiceGrpc;
+import hanium.user_service.dto.response.SimpleProductDTO;
 import io.grpc.StatusRuntimeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,20 @@ public class ProductUserGrpcClient {
         try {
             ProductMainRequest request = ProductMainRequest.newBuilder().setMemberId(memberId).build();
             return stub.getMainCategory(request).getCategoryList().stream().toList();
+        } catch (StatusRuntimeException e) {
+            throw new CustomException(GrpcUtil.extractErrorCode(e));
+        }
+    }
+
+    // 상대 프로필 > 판매 사품 조회
+    public List<SimpleProductDTO> getSellingProducts(Long memberId) {
+        try {
+            ProductMainRequest request = ProductMainRequest.newBuilder().setMemberId(memberId).build();
+            return stub.getSellingProducts(request)
+                    .getProductsList()
+                    .stream()
+                    .map(SimpleProductDTO::from)
+                    .toList();
         } catch (StatusRuntimeException e) {
             throw new CustomException(GrpcUtil.extractErrorCode(e));
         }

--- a/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
+++ b/user-service/src/main/java/hanium/user_service/grpc/UserGrpcService.java
@@ -271,4 +271,16 @@ public class UserGrpcService extends UserServiceGrpc.UserServiceImplBase {
             responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
         }
     }
+
+    // 타 사용자 프로필 조회
+    @Override
+    public void getOtherProfile(GetProfileRequest request, StreamObserver<GetOtherProfileResponse> responseObserver) {
+        try {
+            OtherProfileResponseDTO dto = profileService.getOtherProfile(request.getMemberId());
+            responseObserver.onNext(MemberGrpcMapper.toOtherProfileResponse(dto));
+            responseObserver.onCompleted();
+        } catch (CustomException e) {
+            responseObserver.onError(GrpcUtil.generateException(e.getErrorCode()));
+        }
+    }
 }

--- a/user-service/src/main/java/hanium/user_service/mapper/MemberGrpcMapper.java
+++ b/user-service/src/main/java/hanium/user_service/mapper/MemberGrpcMapper.java
@@ -1,5 +1,6 @@
 package hanium.user_service.mapper;
 
+import hanium.common.proto.product.SimpleProductResponse;
 import hanium.common.proto.user.*;
 import hanium.user_service.dto.response.*;
 
@@ -90,6 +91,27 @@ public class MemberGrpcMapper {
                 .addAllMainCategory(dto.mainCategory())
                 .setAgreeMarketing(dto.agreeMarketing())
                 .setAgree3RdParty(dto.agree3rdParty())
+                .build();
+    }
+
+    // 타 사용자 프로필 조회
+    public static GetOtherProfileResponse toOtherProfileResponse(OtherProfileResponseDTO dto) {
+        return GetOtherProfileResponse.newBuilder()
+                .setMemberId(dto.memberId())
+                .setNickname(dto.nickname())
+                .setImageUrl(dto.imageUrl())
+                .setScore(dto.score())
+                .addAllMainCategory(dto.mainCategory())
+                .addAllProducts(dto.products().stream().map(MemberGrpcMapper::toSimpleProduct).toList())
+                .build();
+    }
+
+    private static SimpleProductResponse toSimpleProduct(SimpleProductDTO dto) {
+        return SimpleProductResponse.newBuilder()
+                .setProductId(dto.productId())
+                .setTitle(dto.title())
+                .setPrice(dto.price())
+                .setImageUrl(dto.imageUrl())
                 .build();
     }
 }

--- a/user-service/src/main/java/hanium/user_service/service/ProfileService.java
+++ b/user-service/src/main/java/hanium/user_service/service/ProfileService.java
@@ -4,10 +4,7 @@ import hanium.common.proto.user.UpdateProfileRequest;
 import hanium.common.proto.user.UpdateScoreRequest;
 import hanium.user_service.dto.request.GetNicknameRequestDTO;
 import hanium.user_service.dto.request.GetPresignedUrlRequestDTO;
-import hanium.user_service.dto.response.GetNicknameResponseDTO;
-import hanium.user_service.dto.response.PresignedUrlResponseDTO;
-import hanium.user_service.dto.response.ProfileDetailResponseDTO;
-import hanium.user_service.dto.response.ProfileResponseDTO;
+import hanium.user_service.dto.response.*;
 
 public interface ProfileService {
 
@@ -22,4 +19,6 @@ public interface ProfileService {
     ProfileDetailResponseDTO getProfileDetailByMemberId(Long memberId);
 
     void updateScore(UpdateScoreRequest request);
+
+    OtherProfileResponseDTO getOtherProfile(Long memberId);
 }

--- a/user-service/src/main/java/hanium/user_service/service/impl/ProfileServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/ProfileServiceImpl.java
@@ -8,10 +8,7 @@ import hanium.user_service.domain.Member;
 import hanium.user_service.domain.Profile;
 import hanium.user_service.dto.request.GetNicknameRequestDTO;
 import hanium.user_service.dto.request.GetPresignedUrlRequestDTO;
-import hanium.user_service.dto.response.GetNicknameResponseDTO;
-import hanium.user_service.dto.response.PresignedUrlResponseDTO;
-import hanium.user_service.dto.response.ProfileDetailResponseDTO;
-import hanium.user_service.dto.response.ProfileResponseDTO;
+import hanium.user_service.dto.response.*;
 import hanium.user_service.grpc.ProductUserGrpcClient;
 import hanium.user_service.repository.ProfileRepository;
 import hanium.user_service.service.ProfileService;
@@ -97,5 +94,22 @@ public class ProfileServiceImpl implements ProfileService {
         Profile profile = profileRepository.findByMemberIdAndDeletedAtIsNull(request.getMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         profile.addScore((long) request.getAmount());
+    }
+
+    // 타 사용자 프로필 조회
+    @Override
+    public OtherProfileResponseDTO getOtherProfile(Long memberId) {
+        Profile profile = profileRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        List<SimpleProductDTO> sellingProducts = productUserGrpcClient.getSellingProducts(memberId);
+
+        return OtherProfileResponseDTO.builder()
+                .memberId(memberId)
+                .nickname(profile.getNickname())
+                .imageUrl(profile.getImageUrl())
+                .score(profile.getScore())
+                .mainCategory(calculateMainCategory(profile))
+                .products(sellingProducts)
+                .build();
     }
 }

--- a/user-service/src/main/java/hanium/user_service/service/impl/ProfileServiceImpl.java
+++ b/user-service/src/main/java/hanium/user_service/service/impl/ProfileServiceImpl.java
@@ -21,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -89,20 +88,7 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     private List<String> calculateMainCategory(Profile profile) {
-        // TTL 설정으로 너무 자주 계산되는 것을 방지
-        if ((profile.getMainCategory() == null || profile.getMainCategoryTTL() == null)
-                || LocalDateTime.now().isAfter(profile.getMainCategoryTTL())) {
-            List<String> mainCategory =
-                    productUserGrpcClient.getMainCategories(profile.getMember().getId());
-            if (!mainCategory.isEmpty()) {
-                LocalDateTime ttl = LocalDateTime.now().plusWeeks(1);
-                profile.updateMainCategory(mainCategory, ttl);
-                return mainCategory;
-            } else {
-                return List.of();
-            }
-        }
-        return profile.getMainCategory();
+        return productUserGrpcClient.getMainCategories(profile.getMember().getId());
     }
 
     // 신뢰도 점수 업데이트

--- a/user-service/src/test/java/hanium/user_service/UserServiceApplicationTests.java
+++ b/user-service/src/test/java/hanium/user_service/UserServiceApplicationTests.java
@@ -1,5 +1,6 @@
 package hanium.user_service;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -7,6 +8,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(classes = UserServiceApplication.class,
         webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ActiveProfiles("test")
+@Disabled
 class UserServiceApplicationTests {
 
     @Test


### PR DESCRIPTION
## 💡 관련 이슈
<!-- 관련된 이슈를 연결해주세요 -->
- Closes #112 

## 💼 작업 설명
<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->
타 사용자 프로필 조회 API를 구현했습니다. 

<img width="588" height="46" alt="image" src="https://github.com/user-attachments/assets/e80cb2d9-6ac6-4ed0-80a3-3f3158a653ce" />


## ✅ 구현/변경사항
<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
- 주요 활동 카테고리 관련 리포지토리 쿼리 수정
- 필요한 grpc 메시지 추가 및 컨트롤러/dto/서비스 구현 
- UserServiceApplicationTests 통합파일 disabled 처리 

## 📝 리뷰 요구사항
<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->